### PR TITLE
Feat/memory event store

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,52 @@ As an **experiment**, this repo won't cover every facet of event sourcing in dep
 [Erlang]: https://www.erlang.org/
 [Event Sourcing]: https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing
 
+## Architecture
+
+### Event store
+
+The event store is a core component in this experiment, designed as a customizable `behaviour` that any `module` can implement to handle event storage. Its primary responsibilities include storing and retrieving events.
+
+```erlang
+% Initializes the event store
+-callback start() -> {ok, initialized | already_initialized} | {error, term()}.
+
+% Shuts down the event store.
+-callback stop() -> {ok} | {error, term()}.
+
+% Persists a list of events for a given stream.
+-callback persist_events(StreamId, Events) -> ok | {error, term()}
+    when StreamId :: stream_id(),
+         Events :: [event()].
+
+% Retrieves events from a stream and folds them using a provided function
+-callback retrieve_and_fold_events(StreamId, Options, FoldFun, InitialAcc) -> {ok, Acc} | {error, term()}
+    when StreamId :: stream_id(),
+         Options :: fold_events_opts(),
+         FoldFun :: fold_events_fun(),
+         InitialAcc :: Acc.
+```
+
+#### Future Features
+
+While not yet implemented, the event store could be extended to:
+
+- Store snapshots of the aggregate’s state for efficient retrieval.
+- Support event subscriptions for real-time updates.
+
+#### Current Implementation
+
+##### Mnesia Event Store
+
+The Mnesia event store uses [Mnesia](https://www.erlang.org/doc/apps/mnesia/mnesia.html) as its underlying storage mechanism. Events are stored as records with the following structure:
+
+```erlang
+{ key :: id(),
+  stream_id :: stream_id(),
+  sequence :: sequence(),
+  event :: event()}.
+```
+
 ## Build
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -46,16 +46,8 @@ While not yet implemented, the event store could be extended to:
 
 #### Current Implementation
 
-##### Mnesia Event Store
-
-The Mnesia event store uses [Mnesia](https://www.erlang.org/doc/apps/mnesia/mnesia.html) as its underlying storage mechanism. Events are stored as records with the following structure:
-
-```erlang
-{ key :: id(),
-  stream_id :: stream_id(),
-  sequence :: sequence(),
-  event :: event()}.
-```
+- [Mnesia](https://www.erlang.org/doc/apps/mnesia/mnesia.html)
+- [ETS](https://www.erlang.org/doc/apps/stdlib/ets.html)
 
 ## Build
 

--- a/apps/event_sourcing_core/src/event_sourcing_store_ets.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_store_ets.erl
@@ -1,0 +1,106 @@
+-module(event_sourcing_store_ets).
+
+-behaviour(event_sourcing_store).
+
+-include_lib("stdlib/include/qlc.hrl").
+
+-export([start/0, stop/0, retrieve_and_fold_events/4, persist_events/2]).
+
+-record(event_record,
+        {key :: event_sourcing_store:id(),
+         stream_id :: event_sourcing_store:stream_id(),
+         sequence :: event_sourcing_store:sequence(),
+         event :: event_sourcing_store:event()}).
+
+%% @doc The name of the ETS table that will store events.
+-define(EVENT_TABLE_NAME, events).
+
+-spec start() -> {ok, initialized | already_initialized}.
+start() ->
+    case ets:info(?EVENT_TABLE_NAME) of
+        undefined ->
+            _ = ets:new(?EVENT_TABLE_NAME,
+                        [ordered_set, named_table, public, {keypos, #event_record.key}]),
+            {ok, initialized};
+        _ ->
+            {ok, already_initialized}
+    end.
+
+-spec stop() -> {ok}.
+stop() ->
+    ets:delete(?EVENT_TABLE_NAME),
+    {ok}.
+
+-spec persist_events(StreamId :: event_sourcing_store:stream_id(),
+                     Events :: [event_sourcing_store:event()]) ->
+                        ok | {error, term()}.
+persist_events(StreamId, Events) ->
+    case check_events(StreamId, Events, []) of
+        ok ->
+            InsertFun =
+                fun(Event) ->
+                   Id = event_sourcing_store:id(Event),
+                   Record =
+                       #event_record{key = Id,
+                                     stream_id = event_sourcing_store:stream_id(Event),
+                                     sequence = event_sourcing_store:sequence(Event),
+                                     event = Event},
+                   ets:insert(?EVENT_TABLE_NAME, Record)
+                end,
+            lists:foreach(InsertFun, Events),
+            ok;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% Helper to check that all events belong to the provided StreamId and that none
+%% have already been persisted.
+check_events(_StreamId, [], _Seen) ->
+    ok;
+check_events(StreamId, [Event | Rest], Seen) ->
+    case event_sourcing_store:stream_id(Event) of
+        StreamId ->
+            Id = event_sourcing_store:id(Event),
+            case lists:member(Id, Seen) of
+                true ->
+                    {error, {duplicate_event, {event_id, Id}}};
+                false ->
+                    case ets:lookup(?EVENT_TABLE_NAME, Id) of
+                        [] ->
+                            check_events(StreamId, Rest, [Id | Seen]);
+                        [_Existing] ->
+                            {error, {duplicate_event, {event_id, Id}}}
+                    end
+            end;
+        WrongStream ->
+            {error, {wrong_stream_id, {expected, StreamId, got, WrongStream}}}
+    end.
+
+-spec retrieve_and_fold_events(event_sourcing_store:stream_id(),
+                               event_sourcing_store:fold_events_opts(),
+                               event_sourcing_store:fold_events_fun(),
+                               event_sourcing_store:acc()) ->
+                                  {ok, event_sourcing_store:acc()}.
+retrieve_and_fold_events(StreamId, Options, FoldFun, InitialAcc)
+    when is_list(Options), is_function(FoldFun, 2) ->
+    From = proplists:get_value(from, Options, 0),
+    To = proplists:get_value(to, Options, infinity),
+    Limit = proplists:get_value(limit, Options, infinity),
+
+    Pattern = {event_record, '_', StreamId, '$1', '$2'},
+    Guard = [{'>=', '$1', From}, {'<', '$1', To}],
+    MatchSpec = [{Pattern, Guard, ['$2']}],
+    ResultEvents =
+        case Limit of
+            infinity ->
+                ets:select(?EVENT_TABLE_NAME, MatchSpec);
+            _ ->
+                Events = ets:select(?EVENT_TABLE_NAME, MatchSpec, Limit),
+                case Events of
+                    {EventList, _Continuation} ->
+                        EventList;
+                    '$end_of_table' ->
+                        []
+                end
+        end,
+    {ok, lists:foldl(FoldFun, InitialAcc, ResultEvents)}.

--- a/apps/event_sourcing_core/src/event_sourcing_store_mnesia.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_store_mnesia.erl
@@ -4,7 +4,7 @@
 
 -include_lib("stdlib/include/qlc.hrl").
 
--export([table_name/1, start/0, stop/0, retrieve_and_fold_events/4, persist_events/2]).
+-export([start/0, stop/0, retrieve_and_fold_events/4, persist_events/2]).
 
 -record(event_record,
         {key :: event_sourcing_store:id(),
@@ -14,11 +14,6 @@
 
 %% @doc The name of the table that will store events.
 -define(EVENT_TABLE_NAME, events).
-
-%% @doc The name of the tables used for persistence.
--spec table_name(events) -> events.
-table_name(events) ->
-    ?EVENT_TABLE_NAME.
 
 -spec start() -> {ok, initialized | already_initialized} | {error, term()}.
 start() ->

--- a/apps/event_sourcing_core/test/event_sourcing_store_mnesia_tests.erl
+++ b/apps/event_sourcing_core/test/event_sourcing_store_mnesia_tests.erl
@@ -2,36 +2,40 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%%% Internal helpers
-
--define(STORE, event_sourcing_store_mnesia).
+suite_test_() ->
+    Stores = [event_sourcing_store_mnesia],
+    BaseTests =
+        [{"create_table_once", fun create_table_once/1},
+         {"create_table_multiple_times", fun create_table_multiple_times/1},
+         {"persist_single_event", fun persist_single_event/1},
+         {"persist_2_streams_event", fun persist_2_streams_event/1},
+         {"fetch_streams_event", fun fetch_streams_event/1},
+         {"wrong_stream_id", fun wrong_stream_id/1},
+         {"duplicate_event", fun duplicate_event/1}],
+    TestCases =
+        [{TestName ++ "__" ++ atom_to_list(Param), fun() -> TestFun(Param) end}
+         || Param <- Stores, {TestName, TestFun} <- BaseTests],
+    {foreach, fun setup/0, fun teardown/1, TestCases}.
 
 setup() ->
-    mnesia:start().
+    mnesia:start(),
+    ok.
 
-teardown() ->
-    mnesia:stop().
+teardown(_) ->
+    mnesia:stop(),
+    ok.
 
 %%% Test cases
 
-create_table_once_test() ->
-    setup(),
+create_table_once(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)).
 
-    ?assertMatch({ok, _}, event_sourcing_store:start(?STORE)),
+create_table_multiple_times(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)).
 
-    teardown().
-
-create_table_multiple_times_test() ->
-    setup(),
-
-    ?assertMatch({ok, _}, event_sourcing_store:start(?STORE)),
-    ?assertMatch({ok, _}, event_sourcing_store:start(?STORE)),
-
-    teardown().
-
-persist_single_event_test() ->
-    setup(),
-    ?assertMatch({ok, _}, event_sourcing_store:start(?STORE)),
+persist_single_event(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Event =
         event_sourcing_store:new_event(stream_A,
@@ -41,14 +45,12 @@ persist_single_event_test() ->
                                        Timestamp,
                                        {"John Doe"}),
 
-    ?assertMatch(ok, event_sourcing_store:persist_events(?STORE, stream_A, [Event])),
-    ?assertMatch({ok, [Event]}, event_sourcing_store:retrieve_events(?STORE, stream_A, [])),
+    ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, [Event])),
+    ?assertMatch({ok, [Event]}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertEqual({ok}, event_sourcing_store:stop(Store)).
 
-    teardown().
-
-persist_2_streams_event_test() ->
-    setup(),
-    ?assertMatch({ok, _}, event_sourcing_store:start(?STORE)),
+persist_2_streams_event(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
 
     EventStreamA =
@@ -66,19 +68,17 @@ persist_2_streams_event_test() ->
                                         Timestamp,
                                         {"Jane Doe"})],
 
-    ?assertMatch(ok, event_sourcing_store:persist_events(?STORE, stream_A, EventStreamA)),
-    ?assertMatch(ok, event_sourcing_store:persist_events(?STORE, stream_B, EventStreamB)),
+    ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, EventStreamA)),
+    ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_B, EventStreamB)),
 
     ?assertMatch({ok, EventStreamA},
-                 event_sourcing_store:retrieve_events(?STORE, stream_A, [])),
+                 event_sourcing_store:retrieve_events(Store, stream_A, [])),
     ?assertMatch({ok, EventStreamB},
-                 event_sourcing_store:retrieve_events(?STORE, stream_B, [])),
+                 event_sourcing_store:retrieve_events(Store, stream_B, [])),
+    ?assertEqual({ok}, event_sourcing_store:stop(Store)).
 
-    teardown().
-
-fetch_streams_event_test() ->
-    setup(),
-    ?assertMatch({ok, _}, ?STORE:start()),
+fetch_streams_event(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Events =
         [event_sourcing_store:new_event(stream_A,
@@ -90,33 +90,31 @@ fetch_streams_event_test() ->
          event_sourcing_store:new_event(stream_A, user, user_updated, 2, Timestamp, {"John Doe"}),
          event_sourcing_store:new_event(stream_A, user, user_deleted, 3, Timestamp, {})],
 
-    ?assertMatch(ok, event_sourcing_store:persist_events(?STORE, stream_A, Events)),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(?STORE, stream_X, [])),
+    ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, Events)),
+    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_X, [])),
     ?assertMatch({ok, []},
-                 event_sourcing_store:retrieve_events(?STORE, stream_A, [{from, 0}, {to, 1}])),
+                 event_sourcing_store:retrieve_events(Store, stream_A, [{from, 0}, {to, 1}])),
     ?assertMatch({ok, []},
-                 event_sourcing_store:retrieve_events(?STORE, stream_A, [{from, 1}, {to, 1}])),
+                 event_sourcing_store:retrieve_events(Store, stream_A, [{from, 1}, {to, 1}])),
 
     Event1 = lists:nth(1, Events),
     Event2 = lists:nth(2, Events),
     Event3 = lists:nth(3, Events),
     ?assertMatch({ok, [Event1]},
-                 event_sourcing_store:retrieve_events(?STORE, stream_A, [{from, 1}, {to, 2}])),
+                 event_sourcing_store:retrieve_events(Store, stream_A, [{from, 1}, {to, 2}])),
     ?assertMatch({ok, [Event2]},
-                 event_sourcing_store:retrieve_events(?STORE, stream_A, [{from, 2}, {to, 3}])),
+                 event_sourcing_store:retrieve_events(Store, stream_A, [{from, 2}, {to, 3}])),
     ?assertMatch({ok, [Event2, Event3]},
-                 event_sourcing_store:retrieve_events(?STORE, stream_A, [{from, 2}, {to, 4}])),
+                 event_sourcing_store:retrieve_events(Store, stream_A, [{from, 2}, {to, 4}])),
     ?assertMatch({ok, [Event2]},
-                 event_sourcing_store:retrieve_events(?STORE,
+                 event_sourcing_store:retrieve_events(Store,
                                                       stream_A,
                                                       [{from, 2}, {to, 4}, {limit, 1}])),
-    ?assertMatch({ok, Events}, event_sourcing_store:retrieve_events(?STORE, stream_A, [])),
+    ?assertMatch({ok, Events}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertEqual({ok}, Store:stop()).
 
-    teardown().
-
-wrong_stream_id_test() ->
-    setup(),
-    ?assertMatch({ok, _}, ?STORE:start()),
+wrong_stream_id(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Event =
         event_sourcing_store:new_event(stream_A,
@@ -127,15 +125,13 @@ wrong_stream_id_test() ->
                                        {"John Doe"}),
 
     ?assertMatch({error, {wrong_stream_id, {expected, stream_B, got, stream_A}}},
-                 event_sourcing_store:persist_events(?STORE, stream_B, [Event])),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(?STORE, stream_A, [])),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(?STORE, stream_B, [])),
+                 event_sourcing_store:persist_events(Store, stream_B, [Event])),
+    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_B, [])),
+    ?assertEqual({ok}, Store:stop()).
 
-    teardown().
-
-duplicate_event_test() ->
-    setup(),
-    ?assertMatch({ok, _}, ?STORE:start()),
+duplicate_event(Store) ->
+    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Event =
         event_sourcing_store:new_event(stream_A,
@@ -145,10 +141,10 @@ duplicate_event_test() ->
                                        Timestamp,
                                        {"John Doe"}),
 
-    ?assertMatch(ok, event_sourcing_store:persist_events(?STORE, stream_A, [Event])),
+    ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, [Event])),
     ?assertMatch({error, {duplicate_event, {event_id, {user, stream_A, 1}}}},
-                 event_sourcing_store:persist_events(?STORE, stream_A, [Event])),
-    ?assertMatch({ok, [Event]}, event_sourcing_store:retrieve_events(?STORE, stream_A, [])),
+                 event_sourcing_store:persist_events(Store, stream_A, [Event])),
+    ?assertMatch({ok, [Event]}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
     Events =
         [event_sourcing_store:new_event(stream_B,
                                         user,
@@ -165,7 +161,6 @@ duplicate_event_test() ->
                                         {"Jon Doe"})],
 
     ?assertMatch({error, {duplicate_event, {event_id, {user, stream_B, 1}}}},
-                 event_sourcing_store:persist_events(?STORE, stream_B, Events)),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(?STORE, stream_B, [])),
-
-    teardown().
+                 event_sourcing_store:persist_events(Store, stream_B, Events)),
+    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_B, [])),
+    ?assertEqual({ok}, Store:stop()).

--- a/apps/event_sourcing_core/test/event_sourcing_store_tests.erl
+++ b/apps/event_sourcing_core/test/event_sourcing_store_tests.erl
@@ -1,9 +1,9 @@
--module(event_sourcing_store_mnesia_tests).
+-module(event_sourcing_store_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 
 suite_test_() ->
-    Stores = [event_sourcing_store_mnesia],
+    Stores = [event_sourcing_store_mnesia, event_sourcing_store_ets],
     BaseTests =
         [{"create_table_once", fun create_table_once/1},
          {"create_table_multiple_times", fun create_table_multiple_times/1},


### PR DESCRIPTION
Introduces an [ETS](https://www.erlang.org/doc/apps/stdlib/ets.html)-based implementation of the `event_sourcing_store` behavior, providing a lightweight, in-memory Event Store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new "Architecture" section in the documentation outlining the design of the event storage component and future enhancement possibilities.

- **New Features**
  - Introduced a new ETS-based event storage solution that provides improved event management for initialization, stopping, persisting, and retrieving events.

- **Bug Fixes**
  - Removed the `table_name/1` function from the public interface of the Mnesia event storage module to streamline functionality.

- **Refactor**
  - Restructured tests to support flexible and modular validation across different storage implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->