### PR TITLE
Refactor/event store

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,3 +2,4 @@
 skip = *.json,*.ttl,CHANGELOG.md,_build
 count = true
 quiet-level = 3
+ignore-words-list = AccOut

--- a/apps/event_sourcing_core/src/event_sourcing_store.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_store.erl
@@ -91,21 +91,21 @@ stop(Module) ->
          Events :: [event()].
 persist_events(StoreModule, StreamId, Events) when is_list(Events) ->
     _ = lists:foldl(fun(Event, Seen) ->
-                   case stream_id(Event) of
-                       StreamId ->
-                           Id = id(Event),
-                           case lists:member(Id, Seen) of
-                               true ->
-                                   erlang:error(duplicate_event);
-                               false ->
-                                   [Id | Seen]
-                           end;
-                       WrongStreamId ->
-                           erlang:error({badarg, WrongStreamId})
-                   end
-                end,
-                [],
-                Events),
+                       case stream_id(Event) of
+                           StreamId ->
+                               Id = id(Event),
+                               case lists:member(Id, Seen) of
+                                   true ->
+                                       erlang:error(duplicate_event);
+                                   false ->
+                                       [Id | Seen]
+                               end;
+                           WrongStreamId ->
+                               erlang:error({badarg, WrongStreamId})
+                       end
+                    end,
+                    [],
+                    Events),
     StoreModule:persist_events(StreamId, Events).
 
 %% @doc

--- a/apps/event_sourcing_core/src/event_sourcing_store.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_store.erl
@@ -14,8 +14,7 @@
          payload/1, new_event/8, new_event/6]).
 
 -export_type([id/0, event/0, stream_id/0, payload/0, sequence/0, fold_events_opts/0,
-              fold_events_fun/0, acc/0, domain/0, type/0, tags/0, metadata/0, timestamp/0,
-              store/0]).
+              domain/0, type/0, tags/0, metadata/0, timestamp/0, store/0]).
 
 %% @doc
 %% Starts the event store, performing any necessary initialization.
@@ -24,21 +23,18 @@
 %% database connections, initializing in-memory structures). Implementations
 %% should be idempotent, allowing repeated calls without side effects.
 %%
-%% @returns
-%% - `{ok, initialized}` if the store was successfully initialized for the first time.
-%% - `{ok, already_initialized}` if the store was already running.
-%% - `{error, Reason}` if initialization failed, where `Reason` describes the failure
-%%   (e.g., `db_connection_failed`).
--callback start() -> {ok, initialized | already_initialized} | {error, term()}.
+%% Returns `ok` on success. May throw an exception if initialization fails
+%% (e.g., resource unavailable).
+-callback start() -> ok.
 %% @doc
 %% This callback function is used to stop the event store.
 %%
 %% The callback should perform any necessary cleanup of the event store.
+%% The function should be idempotent, allowing repeated calls without side effects.
 %%
-%% It should return either {ok} if the stop operation was successful,
-%% or {error, Reason} if there was an error, where `Reason` is a term
-%% describing the error.
--callback stop() -> {ok} | {error, term()}.
+%% Returns `ok` on success. May throw an exception if cleanup fails
+%% (e.g., resource not found).
+-callback stop() -> ok.
 %% @doc
 %% Append events to an event stream.
 %%
@@ -47,11 +43,9 @@
 %% @param StreamId An atom identifying the event stream (e.g., order-123).
 %% @param Events The list of events to append to the stream.
 %%
-%% @returns
-%% - `ok` if the event was persisted.
-%% - `{error, Reason}` if persistence failed (e.g., `wrong_stream_id` if an event’s stream id
-%% does not match the given StreamId).
--callback persist_events(StreamId, Events) -> ok | {error, term()}
+%% Returns `ok` on success. May throw an exception if persistence fails (e.g., badarg if the
+%% stream ID is incorrect, duplicate events if the sequence number is not unique).
+-callback persist_events(StreamId, Events) -> ok
     when StreamId :: stream_id(),
          Events :: [event()].
 %% @doc
@@ -66,51 +60,58 @@
 %%   - `{from, Sequence}`: Start at this sequence (default: 0).
 %%   - `{to, Sequence | infinity}`: End at this sequence (default: infinity).
 %%   - `{limit, Limit}`: Maximum number of events to retrieve (default: infinity).
-%% @param FoldFun A function `fun((EventRecord, Acc) -> NewAcc)` to process each event.
+%% @param FoldFun A function `fun((Event, AccIn) -> AccOut)` to process each event.
 %% @param InitialAcc The initial accumulator value (e.g., an empty state).
 %%
 %% @returns
 %% - `{ok, Acc}` where `Acc` is the result of folding all events.
-%% - `{error, Reason}` if retrieval fails (e.g., `stream_not_found`).
--callback retrieve_and_fold_events(StreamId, Options, FoldFun, InitialAcc) ->
-                                      {ok, Acc} | {error, term()}
+-callback retrieve_and_fold_events(StreamId, Options, Fun, Acc0) -> Acc1
     when StreamId :: stream_id(),
          Options :: fold_events_opts(),
-         FoldFun :: fold_events_fun(),
-         InitialAcc :: Acc.
+         Fun :: fun((Event :: event(), AccIn) -> AccOut),
+         Acc0 :: term(),
+         Acc1 :: term(),
+         AccIn :: term(),
+         AccOut :: term().
 
--spec start(store()) -> {ok, initialized | already_initialized} | {error, term()}.
+-spec start(store()) -> ok.
 start(Module) ->
     Module:start().
 
--spec stop(store()) -> {ok} | {error, term()}.
+-spec stop(store()) -> ok.
 stop(Module) ->
     Module:stop().
 
 %% @doc
 %% Persists a event in the event store using the specified persistence module.
--spec persist_events(StoreModule :: store(),
-                     StreamId :: stream_id(),
-                     Events :: [event()]) ->
-                        ok | {error, term()}.
+-spec persist_events(StoreModule, StreamId, Events) -> ok
+    when StoreModule :: store(),
+         StreamId :: stream_id(),
+         Events :: [event()].
 persist_events(StoreModule, StreamId, Events) when is_list(Events) ->
     StoreModule:persist_events(StreamId, Events).
 
 %% @doc
 %% Retrieves and folds events from the event store using the specified persistence module.
--spec retrieve_and_fold_events(store(),
-                               stream_id(),
-                               fold_events_opts(),
-                               fold_events_fun(),
-                               acc()) ->
-                                  {ok, acc()} | {error, term()}.
-retrieve_and_fold_events(StoreModule, StreamId, Options, Fun, InitialAcc) ->
-    StoreModule:retrieve_and_fold_events(StreamId, Options, Fun, InitialAcc).
+-spec retrieve_and_fold_events(StoreModule, StreamId, Options, Fun, Acc0) -> Acc1
+    when StoreModule :: store(),
+         StreamId :: stream_id(),
+         Options :: fold_events_opts(),
+         Fun :: fun((Event :: event(), AccIn) -> AccOut),
+         Acc0 :: term(),
+         Acc1 :: term(),
+         AccIn :: term(),
+         AccOut :: term().
+retrieve_and_fold_events(StoreModule, StreamId, Options, Fun, InitialResult) ->
+    StoreModule:retrieve_and_fold_events(StreamId, Options, Fun, InitialResult).
 
 %% @doc
 %% Retrieves events for a given stream using the specified store module and options.
--spec retrieve_events(store(), stream_id(), fold_events_opts()) ->
-                         {ok, [event()]} | {error, term()}.
+-spec retrieve_events(StoreModule, StreamId, Options) -> Result
+    when StoreModule :: store(),
+         StreamId :: stream_id(),
+         Options :: fold_events_opts(),
+         Result :: [event()].
 retrieve_events(StoreModule, StreamId, Options) ->
     retrieve_and_fold_events(StoreModule,
                              StreamId,
@@ -131,8 +132,6 @@ retrieve_events(StoreModule, StreamId, Options) ->
     [{from, non_neg_integer()} |
      {to, non_neg_integer() | infinity} |
      {limit, pos_integer() | infinity}].
--type fold_events_fun() :: fun((event(), acc()) -> acc()).
--type acc() :: any().
 -type store() :: module().
 
 %% @doc

--- a/apps/event_sourcing_core/test/event_sourcing_store_tests.erl
+++ b/apps/event_sourcing_core/test/event_sourcing_store_tests.erl
@@ -5,8 +5,8 @@
 suite_test_() ->
     Stores = [event_sourcing_store_mnesia, event_sourcing_store_ets],
     BaseTests =
-        [{"create_table_once", fun create_table_once/1},
-         {"create_table_multiple_times", fun create_table_multiple_times/1},
+        [{"start_once", fun start_once/1},
+         {"start_multiple_times", fun start_multiple_times/1},
          {"persist_single_event", fun persist_single_event/1},
          {"persist_2_streams_event", fun persist_2_streams_event/1},
          {"fetch_streams_event", fun fetch_streams_event/1},
@@ -27,15 +27,15 @@ teardown(_) ->
 
 %%% Test cases
 
-create_table_once(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)).
+start_once(Store) ->
+    ?assertMatch(ok, event_sourcing_store:start(Store)).
 
-create_table_multiple_times(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)).
+start_multiple_times(Store) ->
+    ?assertMatch(ok, event_sourcing_store:start(Store)),
+    ?assertMatch(ok, event_sourcing_store:start(Store)).
 
 persist_single_event(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
+    ?assertMatch(ok, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Event =
         event_sourcing_store:new_event(stream_A,
@@ -46,11 +46,11 @@ persist_single_event(Store) ->
                                        {"John Doe"}),
 
     ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, [Event])),
-    ?assertMatch({ok, [Event]}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
-    ?assertEqual({ok}, event_sourcing_store:stop(Store)).
+    ?assertMatch([Event], event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertEqual(ok, event_sourcing_store:stop(Store)).
 
 persist_2_streams_event(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
+    ?assertMatch(ok, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
 
     EventStreamA =
@@ -71,14 +71,12 @@ persist_2_streams_event(Store) ->
     ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, EventStreamA)),
     ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_B, EventStreamB)),
 
-    ?assertMatch({ok, EventStreamA},
-                 event_sourcing_store:retrieve_events(Store, stream_A, [])),
-    ?assertMatch({ok, EventStreamB},
-                 event_sourcing_store:retrieve_events(Store, stream_B, [])),
-    ?assertEqual({ok}, event_sourcing_store:stop(Store)).
+    ?assertMatch(EventStreamA, event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertMatch(EventStreamB, event_sourcing_store:retrieve_events(Store, stream_B, [])),
+    ?assertEqual(ok, event_sourcing_store:stop(Store)).
 
 fetch_streams_event(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
+    ?assertMatch(ok, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Events =
         [event_sourcing_store:new_event(stream_A,
@@ -91,30 +89,30 @@ fetch_streams_event(Store) ->
          event_sourcing_store:new_event(stream_A, user, user_deleted, 3, Timestamp, {})],
 
     ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, Events)),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_X, [])),
-    ?assertMatch({ok, []},
+    ?assertMatch([], event_sourcing_store:retrieve_events(Store, stream_X, [])),
+    ?assertMatch([],
                  event_sourcing_store:retrieve_events(Store, stream_A, [{from, 0}, {to, 1}])),
-    ?assertMatch({ok, []},
+    ?assertMatch([],
                  event_sourcing_store:retrieve_events(Store, stream_A, [{from, 1}, {to, 1}])),
 
     Event1 = lists:nth(1, Events),
     Event2 = lists:nth(2, Events),
     Event3 = lists:nth(3, Events),
-    ?assertMatch({ok, [Event1]},
+    ?assertMatch([Event1],
                  event_sourcing_store:retrieve_events(Store, stream_A, [{from, 1}, {to, 2}])),
-    ?assertMatch({ok, [Event2]},
+    ?assertMatch([Event2],
                  event_sourcing_store:retrieve_events(Store, stream_A, [{from, 2}, {to, 3}])),
-    ?assertMatch({ok, [Event2, Event3]},
+    ?assertMatch([Event2, Event3],
                  event_sourcing_store:retrieve_events(Store, stream_A, [{from, 2}, {to, 4}])),
-    ?assertMatch({ok, [Event2]},
+    ?assertMatch([Event2],
                  event_sourcing_store:retrieve_events(Store,
                                                       stream_A,
                                                       [{from, 2}, {to, 4}, {limit, 1}])),
-    ?assertMatch({ok, Events}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
-    ?assertEqual({ok}, Store:stop()).
+    ?assertMatch(Events, event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertEqual(ok, Store:stop()).
 
 wrong_stream_id(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
+    ?assertMatch(ok, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Event =
         event_sourcing_store:new_event(stream_A,
@@ -124,14 +122,15 @@ wrong_stream_id(Store) ->
                                        Timestamp,
                                        {"John Doe"}),
 
-    ?assertMatch({error, {wrong_stream_id, {expected, stream_B, got, stream_A}}},
-                 event_sourcing_store:persist_events(Store, stream_B, [Event])),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_B, [])),
-    ?assertEqual({ok}, Store:stop()).
+    ?assertException(error,
+                     {badarg, stream_A},
+                     event_sourcing_store:persist_events(Store, stream_B, [Event])),
+    ?assertMatch([], event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertMatch([], event_sourcing_store:retrieve_events(Store, stream_B, [])),
+    ?assertEqual(ok, Store:stop()).
 
 duplicate_event(Store) ->
-    ?assertMatch({ok, _}, event_sourcing_store:start(Store)),
+    ?assertMatch(ok, event_sourcing_store:start(Store)),
     Timestamp = calendar:universal_time(),
     Event =
         event_sourcing_store:new_event(stream_A,
@@ -142,9 +141,10 @@ duplicate_event(Store) ->
                                        {"John Doe"}),
 
     ?assertMatch(ok, event_sourcing_store:persist_events(Store, stream_A, [Event])),
-    ?assertMatch({error, {duplicate_event, {event_id, {user, stream_A, 1}}}},
-                 event_sourcing_store:persist_events(Store, stream_A, [Event])),
-    ?assertMatch({ok, [Event]}, event_sourcing_store:retrieve_events(Store, stream_A, [])),
+    ?assertException(error,
+                     duplicate_event,
+                     event_sourcing_store:persist_events(Store, stream_A, [Event])),
+    ?assertMatch([Event], event_sourcing_store:retrieve_events(Store, stream_A, [])),
     Events =
         [event_sourcing_store:new_event(stream_B,
                                         user,
@@ -160,7 +160,8 @@ duplicate_event(Store) ->
                                         Timestamp,
                                         {"Jon Doe"})],
 
-    ?assertMatch({error, {duplicate_event, {event_id, {user, stream_B, 1}}}},
-                 event_sourcing_store:persist_events(Store, stream_B, Events)),
-    ?assertMatch({ok, []}, event_sourcing_store:retrieve_events(Store, stream_B, [])),
-    ?assertEqual({ok}, Store:stop()).
+    ?assertException(error,
+                     duplicate_event,
+                     event_sourcing_store:persist_events(Store, stream_B, Events)),
+    ?assertMatch([], event_sourcing_store:retrieve_events(Store, stream_B, [])),
+    ?assertEqual(ok, Store:stop()).


### PR DESCRIPTION
This PR introduces several improvements to the event store design (once again):
- Adopt _fail-fast_ callback semantics: Event store _callbacks_ now follow a fail-fast approach by raising exceptions (`badarg`, `duplicate_event`) instead of returning error tuples. I believe it aligns with Erlang/OTP idioms in those specific cases.
- Centralize precondition checks: Stream ID validation and duplicate detection are now handled at the event store level, ensuring consistent behavior across all backend implementations.
- Fix / optimize ETS backend with _batch_ insert: The ETS backend now uses https://www.erlang.org/doc/apps/stdlib/ets.html#insert_new/2 with a list of event records, ensuring atomic insertion of events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined event processing across the platform by simplifying response structures to return clear, direct success indicators and by moving error signaling to exceptions.
  - Removed unnecessary exported types and simplified callback specifications for better clarity and usability.

- **Tests**
  - Updated validation tests to directly confirm the new response patterns and to assert exceptions for error scenarios, ensuring improved clarity and consistency in behavior.
  - Renamed test cases for better alignment with their functionality and simplified assertions for readability. 

- **Chores**
  - Added a configuration option to the spell-checking process to ignore specific terms, enhancing customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->