### PR TITLE
Feat/mgr aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,59 @@ When no messages are received within the timeout window:
 - Its state is discarded.
 - Future commands will cause the manager to rehydrate it from persisted events.
 
+### Aggregate Manager
+
+The _aggregate manager_ is implemented as a [gen_server](https://www.erlang.org/doc/apps/stdlib/gen_server.html). It serves as a router and supervisor for aggregate processes, ensuring that commands are dispatched to the correct aggregate instance based on their stream ID.
+
+The manager is responsible for:
+
+- Routing commands to the appropriate aggregate process.
+- Managing the lifecycle of aggregate instances, starting new ones as needed.
+- Monitoring aggregate processes and cleaning up when they terminate.
+
+#### How it works
+
+The aggregate manager maintains a mapping of stream IDs to aggregate process PIDs. When a command is received:
+
+1. The `Router` module extracts the target aggregate type and stream ID from the command.
+2. If the aggregate type matches the manager’s configured `Aggregate` module:
+   - The manager checks its internal `pids` map for an existing process for the stream ID.
+   - If none exists, it spawns a new `event_sourcing_core_aggregate` process using the provided Aggregate, Store, and stream ID, then monitors it.
+   - The command is forwarded to the aggregate process via `event_sourcing_core_aggregate:dispatch/2`.
+3. If the aggregate type mismatches or routing fails, an error is returned.
+
+```mermaid
+flowchart LR
+    %% Aggregate Managers
+    Mgr1((Agg. Mgr<br>Order)):::manager
+    Mgr2((Agg. Mgr<br>User)):::manager
+    Mgr3((Agg. Mgr<br>Bank)):::manager
+
+    %% Aggregate Instances
+    Agg1((Order<br>order-123)):::aggregate
+    Agg1((Order<br>order-123)):::aggregate
+    Agg2((Order<br>order-456)):::aggregate
+    Agg2((Order<br>order-456)):::aggregate
+
+    Agg3((User<br>user-123)):::aggregate
+
+    Mgr1 -->|cmd| Agg1
+    Mgr1 -.-|monitoring| Agg1
+    Mgr1 -->|cmd| Agg2
+    Mgr1 -.-|monitoring| Agg2
+    Mgr2 -->|cmd| Agg3
+    Mgr2 -.-|monitoring| Agg3
+```
+
+#### Options
+
+The manager can be configured with options such as:
+
+- `timeout`: Timeout for operations.
+- `sequence_zero`: Function to initialize event sequences.
+- `sequence_next`: Function to increment sequences.
+- `now_fun`: Function to provide timestamps.
+
 ### Project organization
 
 ```plaintext
@@ -138,12 +191,15 @@ apps/event_sourcing_core
 │   ├── event_sourcing_core.app.src                 % Application definition
 │   ├── event_sourcing_core_aggregate.erl           % Aggregate process (gen_server)
 │   ├── event_sourcing_core_aggregate_behaviour.erl % Aggregate behaviour (domain contract)
+│   ├── event_sourcing_core_mgr_aggregate.erl       % Aggregate manager process (gen_server)
+│   ├── event_sourcing_core_mgr_behaviour.erl       % Aggregate manager behaviour (routing contract)
 │   ├── event_sourcing_core_store.erl               % Event store behaviour
 │   ├── event_sourcing_core_store_ets.erl           % ETS-backed store implementation
 │   └── event_sourcing_core_store_mnesia.erl        % Mnesia-backed store implementation
 └── test
     ├── bank_account_aggregate.erl                  % Sample domain aggregate
     ├── event_sourcing_core_aggregate_tests.erl     % Aggregate process tests
+    ├── event_sourcing_core_mgr_aggregate_tests.erl % Aggregate manager tests
     └── event_sourcing_core_store_tests.erl         % Store behaviour tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,30 @@ sequenceDiagram
     deactivate GenAggregate
 ```
 
-### File Structure
+#### Passivation
+
+Each aggregate instance (a `gen_server`) is automatically passivated — i.e., stopped — after a period of inactivity.
+
+This helps:
+
+- Free up memory in long-lived systems
+- Keep the number of live processes bounded
+- Rehydrate state on demand from the event store
+
+Passivation is configured via a `timeout` value when the aggregate is started (defaults to 5000 ms):
+
+```erlang
+event_sourcing_core_aggregate:start_link(Module, Store, Id, #{timeout => 10000}).
+```
+
+When no messages are received within the timeout window:
+
+- A passivate message is sent to the process.
+- The aggregate process exits normally (`stop`).
+- Its state is discarded.
+- Future commands will cause the manager to rehydrate it from persisted events.
+
+### Project organization
 
 ```plaintext
 apps/event_sourcing_core

--- a/apps/event_sourcing_core/src/event_sourcing_core_aggregate.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_core_aggregate.erl
@@ -22,7 +22,7 @@
 %% @param Id The unique identifier for the aggregate instance.
 %% @param Timeout The inactivity timeout in milliseconds before passivation.
 %% @return `{ok, Pid}` if successful, `{error, Reason}` otherwise.
--spec start_link(Aggregate, Store, Id, Opts) -> {ok, Result} | {error, Reason}
+-spec start_link(Aggregate, Store, Id, Opts) -> gen_server:start_ret()
     when Aggregate :: module(),
          Store :: module(),
          Id :: stream_id(),
@@ -30,9 +30,7 @@
              #{timeout => timeout(),
                sequence_zero => fun(() -> sequence()),
                sequence_next => fun((sequence()) -> sequence()),
-               now_fun => fun(() -> timestamp())},
-         Result :: pid(),
-         Reason :: term().
+               now_fun => fun(() -> timestamp())}.
 start_link(Aggregate, Store, Id, Opts) ->
     gen_server:start_link(?MODULE, {Aggregate, Store, Id, Opts}, []).
 
@@ -43,7 +41,7 @@ start_link(Aggregate, Store, Id, Opts) ->
 %% @param Store The persistence module (event-store) implementing event retrieval.
 %% @param Id The unique identifier for the aggregate instance.
 -spec start_link(Aggregate :: module(), Store :: module(), Id :: stream_id()) ->
-                    {ok, pid()} | {error, term()}.
+                    gen_server:start_ret().
 start_link(Aggregate, Store, Id) ->
     start_link(Aggregate, Store, Id, #{}).
 

--- a/apps/event_sourcing_core/src/event_sourcing_core_mgr_aggregate.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_core_mgr_aggregate.erl
@@ -1,0 +1,242 @@
+%% @doc
+%% This module implements a `gen_server` that manages event-sourcing aggregates.
+%%
+%% It acts as a router and supervisor for aggregate processes, dispatching commands
+%% to the appropriate aggregate instance based on a stream ID. It ensures that each
+%% stream ID maps to a single aggregate process, starting new ones as needed and
+%% monitoring them for crashes.
+-module(event_sourcing_core_mgr_aggregate).
+
+-behaviour(gen_server).
+
+-include_lib("event_sourcing_core.hrl").
+
+-export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2, start_link/4,
+         start_link/3, stop/1, dispatch/2]).
+
+-export_type([command/0, state/0, sequence/0, timestamp/0]).
+
+-record(state,
+        {aggregate :: module(),
+         store :: module(),
+         router :: module(),
+         opts ::
+             #{timeout => timeout(),
+               sequence_zero => fun(() -> sequence()),
+               sequence_next => fun((sequence()) -> sequence()),
+               now_fun => fun(() -> timestamp())},
+         pids :: #{stream_id() => pid()}}).
+
+-opaque state() :: #state{}.
+
+%% @doc
+%% Starts the aggregate manager with custom options.
+%%
+%% @param Aggregate The module implementing the aggregate logic.
+%% @param Store The module implementing the event store.
+%% @param Router The module extracting routing info from commands.
+%% @param Opts Configuration options:
+%%   - `timeout`: Timeout for operations (default: `infinity`).
+%%   - `sequence_zero`: Function to initialize sequence (default: returns 0).
+%%   - `sequence_next`: Function to increment sequence (default: adds 1).
+%%   - `now_fun`: Function to get current timestamp (default: system time).
+%% @returns `{ok, Pid}` on success, or an error tuple if the server fails to start.
+
+-spec start_link(Aggregate, Store, Router, Opts) -> gen_server:start_ret()
+    when Aggregate :: module(),
+         Store :: module(),
+         Router :: module(),
+         Opts ::
+             #{timeout => timeout(),
+               sequence_zero => fun(() -> sequence()),
+               sequence_next => fun((sequence()) -> sequence()),
+               now_fun => fun(() -> timestamp())}.
+start_link(Aggregate, Store, Router, Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, {Aggregate, Store, Router, Opts}, []).
+
+%% @doc
+%% Starts the aggregate manager with the given aggregate, store, and router modules,
+%% using default options.
+%%
+%% @param Aggregate The module implementing the aggregate logic.
+%% @param Store The module implementing the event store.
+%% @param Router The module extracting routing info from commands.
+%% @returns `{ok, Pid}` on success, or an error tuple if the server fails to start.
+-spec start_link(Aggregate, Store, Router) -> gen_server:start_ret()
+    when Aggregate :: module(),
+         Store :: module(),
+         Router :: module().
+start_link(Aggregate, Store, Router) ->
+    start_link(Aggregate, Store, Router, #{}).
+
+%% @doc
+%% Stops the aggregate manager.
+%%
+%% @param ServerRef Reference to the gen_server (e.g., pid or name).
+%% @returns `ok` on success; may throw an exception if the server is unreachable.
+-spec stop(ServerRef) -> ok when ServerRef :: gen_server:server_ref().
+stop(ServerRef) ->
+    gen_server:stop(ServerRef).
+
+%% @doc
+%% Dispatches a command to the appropriate aggregate instance.
+%%
+%% Routes the command via the manager to the aggregate process for the stream ID
+%% extracted by the router module.
+%%
+%% @param Pid The pid of the manager process.
+%% @param Command The command to dispatch.
+%% @returns `{ok, Result}` on success, or `{error, Reason}` if routing or execution fails.
+-spec dispatch(Pid, Command) -> {ok, Result} | {error, Reason}
+    when Pid :: pid(),
+         Command :: command(),
+         Result :: term(),
+         Reason :: term().
+dispatch(Pid, Command) ->
+    gen_server:call(Pid, Command).
+
+%% @doc
+%% Initializes the aggregate manager state.
+%%
+%% @param Args Tuple containing the aggregate, store, router modules, and options.
+%% @returns `{ok, State}` with an initialized state record.
+-spec init({Aggregate, Store, Router, Opts}) -> {ok, State}
+    when Aggregate :: module(),
+         Store :: module(),
+         Router :: module(),
+         Opts ::
+             #{timeout => timeout(),
+               sequence_zero => fun(() -> sequence()),
+               sequence_next => fun((sequence()) -> sequence()),
+               now_fun => fun(() -> timestamp())},
+         State :: state().
+init({Aggregate, Store, Router, Opts}) ->
+    {ok,
+     #state{aggregate = Aggregate,
+            store = Store,
+            router = Router,
+            opts = Opts,
+            pids = #{}}}.
+
+-spec handle_call(Command, From, State) ->
+                     {reply, ok, State} | {reply, {error, Reason}, State}
+    when Command :: command(),
+         From :: {pid(), term()},
+         State :: state(),
+         Reason :: term().
+handle_call(Command, _From, #state{aggregate = Aggregate, router = Router} = State) ->
+    case Router:extract_routing(Command) of
+        {ok, {Aggregate, Id}} ->
+            ensure_and_dispatch(Aggregate, Id, Command, State);
+        {ok, {WrongAgg, _Id}} when WrongAgg =/= Aggregate ->
+            {reply, {error, wrong_aggregate}, State};
+        {error, Reason} ->
+            {reply, {error, Reason}, State}
+    end.
+
+-spec handle_cast(Command, State) -> {noreply, State}
+    when Command :: command(),
+         State :: state().
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec terminate(Reason, State) -> ok
+    when Reason :: term(),
+         State :: state().
+terminate(_Reason, _State) ->
+    ok.
+
+%% @doc
+%% Handles process monitoring messages.
+%%
+%% Removes the pid of a downed aggregate from the state’s `pids` map.
+%%
+%% @param Info The `'DOWN'` message from a monitored process.
+%% @returns `{noreply, State}` with updated state.
+-spec handle_info(Info, State) -> {noreply, State}
+    when Info :: {'DOWN', _Ref, process, Pid, _Reason},
+         State :: state(),
+         Pid :: pid().
+handle_info({'DOWN', _Ref, process, Pid, _Reason}, #state{pids = Pids} = State) ->
+    IdToRemove = maps:filter(fun(_, ThisPid) -> ThisPid =:= Pid end, Pids),
+    case maps:keys(IdToRemove) of
+        [Id] ->
+            NewPids = maps:remove(Id, Pids),
+            {noreply, State#state{pids = NewPids}};
+        [] ->
+            {noreply, State}
+    end;
+handle_info(_Any, State) ->
+    {noreply, State}.
+
+%% @doc
+%% Ensures an aggregate process exists for the stream ID and dispatches the command.
+%%
+%% Starts a new aggregate if none exists, then forwards the command.
+%%
+%% @returns `{reply, {ok, Result}, State}` or `{reply, {error, Reason}, State}`.
+-spec ensure_and_dispatch(Aggregate, Id, Command, State) -> {reply, Result, State}
+    when Aggregate :: module(),
+         Id :: stream_id(),
+         Command :: command(),
+         Result :: term(),
+         State :: state().
+ensure_and_dispatch(Aggregate,
+                    Id,
+                    Command,
+                    #state{store = Store,
+                           pids = Pids,
+                           opts = Opts} =
+                        State) ->
+    case maps:get(Id, Pids, undefined) of
+        undefined ->
+            case start_aggregate(Aggregate, Store, Id, Opts) of
+                {ok, Pid} ->
+                    Result = forward(Pid, Command),
+                    NewPids = maps:put(Id, Pid, Pids),
+                    {reply, Result, State#state{pids = NewPids}};
+                {error, Reason} ->
+                    {reply, {error, Reason}, State}
+            end;
+        Pid ->
+            Result = forward(Pid, Command),
+            {reply, Result, State}
+    end.
+
+%% @doc
+%% Forwards a command to an aggregate process.
+%%
+%% @returns The result of the aggregate’s dispatch function.
+-spec forward(Pid, Command) -> {ok, Result} | {error, Reason}
+    when Pid :: pid(),
+         Command :: command(),
+         Result :: pid(),
+         Reason :: term().
+forward(Pid, Command) ->
+    event_sourcing_core_aggregate:dispatch(Pid, Command).
+
+%% @doc
+%% Starts an aggregate process for a given stream ID.
+%%
+%% Monitors the new process and returns its pid.
+%%
+%% @returns `{ok, Pid}` on success, or `{error, Reason}` on failure.
+-spec start_aggregate(Aggregate, Store, Id, Opts) -> {ok, Result} | {error, Reason}
+    when Aggregate :: module(),
+         Store :: module(),
+         Id :: stream_id(),
+         Opts ::
+             #{timeout => timeout(),
+               sequence_zero => fun(() -> sequence()),
+               sequence_next => fun((sequence()) -> sequence()),
+               now_fun => fun(() -> timestamp())},
+         Result :: pid(),
+         Reason :: term().
+start_aggregate(Aggregate, Store, Id, Opts) ->
+    case event_sourcing_core_aggregate:start_link(Aggregate, Store, Id, Opts) of
+        {ok, Pid} ->
+            erlang:monitor(process, Pid),
+            {ok, Pid};
+        {error, Reason} ->
+            {error, Reason}
+    end.

--- a/apps/event_sourcing_core/src/event_sourcing_core_mgr_behaviour.erl
+++ b/apps/event_sourcing_core/src/event_sourcing_core_mgr_behaviour.erl
@@ -1,0 +1,9 @@
+-module(event_sourcing_core_mgr_behaviour).
+
+-include_lib("event_sourcing_core.hrl").
+
+%% @doc Extracts the routing information from the command.
+%% The routing information is the aggregate module and the stream id.
+-callback extract_routing(Command :: command()) -> {ok, Route} | {error, Reason}
+    when Route :: {Aggregate :: module(), Id :: stream_id()},
+         Reason :: term().

--- a/apps/event_sourcing_core/test/bank_account_aggregate.erl
+++ b/apps/event_sourcing_core/test/bank_account_aggregate.erl
@@ -1,10 +1,11 @@
 -module(bank_account_aggregate).
 
 -behaviour(event_sourcing_core_aggregate_behaviour).
+-behaviour(event_sourcing_core_mgr_behaviour).
 
 %% Callbacks implementation
 
--export([init/0, event_type/1, handle_command/2, apply_event/2]).
+-export([init/0, event_type/1, handle_command/2, apply_event/2, extract_routing/1]).
 
 init() ->
     #{balance => 0}.
@@ -12,11 +13,12 @@ init() ->
 event_type(#{type := Type}) ->
     Type.
 
-handle_command({deposit, Amount}, _) when Amount > 0 ->
+handle_command({bank, deposit, _, Amount}, _) when Amount > 0 ->
     {ok, [#{type => deposited, amount => Amount}]};
-handle_command({withdraw, Amount}, #{balance := Balance}) when Amount =< Balance ->
+handle_command({bank, withdraw, _, Amount}, #{balance := Balance})
+    when Amount =< Balance ->
     {ok, [#{type => withdrawn, amount => Amount}]};
-handle_command({withdraw, Amount}, _) when Amount > 0 ->
+handle_command({bank, withdraw, _, Amount}, _) when Amount > 0 ->
     {error, insufficient_funds};
 handle_command(_, _) ->
     {error, invalid_command}.
@@ -25,3 +27,8 @@ apply_event(#{type := deposited, amount := Amount}, #{balance := Bal}) ->
     #{balance => Bal + Amount};
 apply_event(#{type := withdrawn, amount := Amount}, #{balance := Bal}) ->
     #{balance => Bal - Amount}.
+
+extract_routing({bank, _, Id, _}) ->
+    {ok, {bank_account_aggregate, Id}};
+extract_routing(_) ->
+    {error, invalid_command}.

--- a/apps/event_sourcing_core/test/event_sourcing_core_aggregate_tests.erl
+++ b/apps/event_sourcing_core/test/event_sourcing_core_aggregate_tests.erl
@@ -38,20 +38,20 @@ aggregate_behaviour() ->
 
     ?assertState(Pid, Id, #{balance := 0}, 0),
 
-    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {deposit, 100})),
+    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {bank, deposit, Id, 100})),
     ?assertState(Pid, Id, #{balance := 100}, 1),
 
-    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {deposit, 100})),
+    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {bank, deposit, Id, 100})),
     ?assertState(Pid, Id, #{balance := 200}, 2),
 
-    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {withdraw, 50})),
+    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {bank, withdraw, Id, 50})),
     ?assertState(Pid, Id, #{balance := 150}, 3).
 
 aggregate_passivation() ->
     {Id, Pid} = start_test_account(1000),
 
-    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {deposit, 100})),
-    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {withdraw, 25})),
+    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {bank, deposit, Id, 100})),
+    ?assertEqual(ok, event_sourcing_core_aggregate:dispatch(Pid, {bank, withdraw, Id, 25})),
 
     ?assertState(Pid, Id, #{balance := 75}, 2),
 
@@ -66,12 +66,12 @@ aggregate_passivation() ->
     ?assertState(Pid2, Id, #{balance := 75}, 2).
 
 aggregate_invalid_command() ->
-    {_, Pid} = start_test_account(5000),
+    {Id, Pid} = start_test_account(5000),
 
     ?assertEqual({error, invalid_command},
                  event_sourcing_core_aggregate:dispatch(Pid, invalid)),
     ?assertEqual({error, insufficient_funds},
-                 event_sourcing_core_aggregate:dispatch(Pid, {withdraw, 100})).
+                 event_sourcing_core_aggregate:dispatch(Pid, {bank, withdraw, Id, 100})).
 
 start_test_account(Timeout) ->
     Id = <<"bank-account-123">>,

--- a/apps/event_sourcing_core/test/event_sourcing_core_mgr_aggregate_tests.erl
+++ b/apps/event_sourcing_core/test/event_sourcing_core_mgr_aggregate_tests.erl
@@ -1,0 +1,100 @@
+-module(event_sourcing_core_mgr_aggregate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+suite_test_() ->
+    TestCases =
+        [{"aggregate_behaviour", fun aggregate_behaviour/0},
+         {"aggregate_passivation", fun aggregate_passivation/0},
+         {"aggregate_invalid_command", fun aggregate_invalid_command/0}],
+    {foreach, fun setup/0, fun teardown/1, TestCases}.
+
+setup() ->
+    event_sourcing_core_store:start(event_sourcing_core_store_ets),
+    ok.
+
+teardown(_) ->
+    event_sourcing_core_store:stop(event_sourcing_core_store_ets),
+    ok.
+
+%%%  Test cases
+
+agg_id(Pid, Id) ->
+    {state, _, _, _, _, #{Id := AggPid}} = sys:get_state(Pid),
+    AggPid.
+
+-define(assertState(Pid, Id, ExpectedState, ExpectedSeq),
+        ?assertMatch({state,
+                      bank_account_aggregate,
+                      event_sourcing_core_store_ets,
+                      Id,
+                      ExpectedState,
+                      ExpectedSeq,
+                      _,
+                      _,
+                      _,
+                      _,
+                      _},
+                     sys:get_state(Pid))).
+
+aggregate_behaviour() ->
+    Pid = start_mgr(5000),
+    Id = <<"bank-account-123">>,
+
+    ?assertEqual(ok,
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, deposit, Id, 100})),
+    ?assertState(agg_id(Pid, Id), Id, #{balance := 100}, 1),
+
+    ?assertEqual(ok,
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, deposit, Id, 100})),
+    ?assertState(agg_id(Pid, Id), Id, #{balance := 200}, 2),
+
+    ?assertEqual(ok,
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, withdraw, Id, 50})),
+    ?assertState(agg_id(Pid, Id), Id, #{balance := 150}, 3),
+
+    ?assertEqual(ok, event_sourcing_core_mgr_aggregate:stop(Pid)).
+
+aggregate_passivation() ->
+    Pid = start_mgr(1000),
+    Id = <<"bank-account-123">>,
+
+    ?assertEqual(ok,
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, deposit, Id, 100})),
+    ?assertEqual(ok,
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, withdraw, Id, 25})),
+
+    ?assertState(agg_id(Pid, Id), Id, #{balance := 75}, 2),
+
+    % wait for the aggregate to be passivated
+    timer:sleep(2000),
+
+    % check aggregate is no more alive
+    {_, _, _, _, _, AggPids} = sys:get_state(Pid),
+    ?assertEqual(false, maps:is_key(Id, AggPids)),
+
+    ?assertEqual(ok,
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, deposit, Id, 30})),
+
+    ?assertState(agg_id(Pid, Id), Id, #{balance := 105}, 3),
+
+    ?assertEqual(ok, event_sourcing_core_mgr_aggregate:stop(Pid)).
+
+aggregate_invalid_command() ->
+    Pid = start_mgr(5000),
+    Id = <<"bank-account-123">>,
+
+    ?assertEqual({error, invalid_command},
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, invalid)),
+    ?assertEqual({error, insufficient_funds},
+                 event_sourcing_core_mgr_aggregate:dispatch(Pid, {bank, withdraw, Id, 100})),
+
+    ?assertEqual(ok, event_sourcing_core_mgr_aggregate:stop(Pid)).
+
+start_mgr(Timeout) ->
+    {ok, Pid} =
+        event_sourcing_core_mgr_aggregate:start_link(bank_account_aggregate,
+                                                     event_sourcing_core_store_ets,
+                                                     bank_account_aggregate,
+                                                     #{timeout => Timeout}),
+    Pid.


### PR DESCRIPTION
Time to introduce the aggregate manager [OTP](https://www.erlang.org/doc/readme.html) `gen_server` that serves as a _router_ and _supervisor_ for aggregate processes.

- [x] Defines a [behaviour](https://www.erlang.org/doc/system/design_principles.html#behaviours) for commands routing (`extract_routing/1`).
- [x] Provides a  [gen_server](https://www.erlang.org/doc/apps/stdlib/gen_server.html)-based implementation that handles:
  - [x] _Lifecycle_ management of aggregate instances (starting new ones as needed).
  - [x] _Commands_ Routing to the appropriate aggregate process.
  - [x] Aggregate _monitoring_ processes.
- [x] Docs
- [x] Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced documentation with two new sections explaining the automatic passivation of idle aggregates and the role of the aggregate manager in command routing and process lifecycle management.

- **New Features**
  - Introduced automatic passivation with configurable timeouts to optimize resource usage.
  - Rolled out an aggregate manager to ensure reliable routing and supervision of commands.
  - Updated the banking command structure for deposits, withdrawals, and error handling.

- **Tests**
  - Added comprehensive tests to validate aggregate behavior, passivation, and improved command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->