### PR TITLE
build(release): add escript to generate release BOM

### DIFF
--- a/.github/scripts/generate_release_bom.escript
+++ b/.github/scripts/generate_release_bom.escript
@@ -1,0 +1,59 @@
+#!/usr/bin/env escript
+%%! -mode(compile).
+
+-define(OUTPUT_FILE, "bom.yml").
+
+main([Release]) ->
+    write_bom(Release);
+main(_) ->
+    usage(),
+    halt(1).
+
+usage() ->
+    io:format("Usage: generate_release_bom.escript <release-version>~n").
+
+write_bom(Release) ->
+    Files = filelib:wildcard("apps/*/src/*.app.src"),
+    Apps = lists:sort(fun sort_apps/2, [read_app(File) || File <- Files]),
+    Timestamp = calendar:local_time(),
+    DateString = format_date(Timestamp),
+    Lines = [
+        io_lib:format("release: ~s~n", [Release]),
+        io_lib:format("generated_at: ~s~n", [DateString]),
+        "apps:\n"
+    ],
+    AppLines = [io_lib:format("  ~s: \"~s\"~n", [Name, Vsn]) || {Name, Vsn} <- Apps],
+    ok = file:write_file(?OUTPUT_FILE, lists:flatten(Lines ++ AppLines)).
+
+sort_apps({NameA, _}, {NameB, _}) ->
+    NameA =< NameB.
+
+read_app(File) ->
+    case file:consult(File) of
+        {ok, [{application, Name, Props}]} ->
+            extract_vsn(File, Name, Props);
+        {ok, Terms} ->
+            error({unexpected_terms, File, Terms});
+        {error, Reason} ->
+            error({file_error, File, Reason})
+    end.
+
+extract_vsn(File, Name, Props) ->
+    case lists:keyfind(vsn, 1, Props) of
+        {vsn, Vsn} ->
+            {atom_to_list(Name), normalize_vsn(Vsn)};
+        false ->
+            error({missing_vsn, File})
+    end.
+
+normalize_vsn(Vsn) when is_list(Vsn) ->
+    Vsn;
+normalize_vsn(Vsn) when is_binary(Vsn) ->
+    binary_to_list(Vsn);
+normalize_vsn(Vsn) ->
+    io_lib:format("~p", [Vsn]).
+
+format_date({{Year, Month, Day}, _Time}) ->
+    lists:flatten(
+        io_lib:format("~4..0B-~2..0B-~2..0B", [Year, Month, Day])
+    ).

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -62,6 +62,8 @@ plugins:
               numMatches: 1
               numReplacements: 1
   - - "@semantic-release/exec"
+    - prepareCmd: ".github/scripts/generate_release_bom.escript ${nextRelease.version}"
+  - - "@semantic-release/exec"
     - prepareCmd: |
         rebar3 as prod tar
   - - "@semantic-release/github"
@@ -74,4 +76,5 @@ plugins:
         - CHANGELOG.md
         - rebar.config
         - rebar.lock
+        - bom.yml
       message: "chore(release): perform release ${nextRelease.version}"


### PR DESCRIPTION
Generates a `bom.yml` snapshot listing all app versions for each release.

E.g.
```yaml
release: 1.1.0
generated_at: 2025-10-30
apps:
  event_sourcing_contract: "0.1.0"
  event_sourcing_core: "0.1.0"
  event_sourcing_store_ets: "0.1.0"
  event_sourcing_store_mnesia: "0.1.0"
  event_sourcing_xp: "0.1.0"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Releases now include an auto-generated bill of materials (bom.yml) that provides a complete list of all applications and their specific versions included in each release
- The bill of materials is automatically generated during the release process, offering users improved visibility and transparency into the exact composition and components of each release distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->