### PR TITLE
Feat/position

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ As an **experiment**, this repo won't cover every facet of event sourcing in dep
 - **Kernel OTP app** — packaged as an OTP application with a supervision tree (`es_kernel_sup`) that boots a dynamic aggregate supervisor and a singleton aggregate manager. Configure stores via application env, start with `application:ensure_all_started/1`, and dispatch commands through `es_kernel:dispatch/1`.
 - **Aggregate** — a reusable [gen_server](https://www.erlang.org/doc/apps/stdlib/gen_server.html) harness that keeps domain logic pure while delegating event sourcing boilerplate.
 - **Aggregate Manager** — a singleton router that spins up aggregates on demand via the dynamic supervisor, rehydrates them from persisted events, monitors them, and passivates idle instances.
-- **Event Store** — a behaviour-driven abstraction with drop-in backends so you can pick the storage engine that fits your deployment.
+- **Event Store** — a behaviour-driven abstraction with drop-in backends, per-stream replay for aggregates, and global-position replay for read-side projections.
 - **Snapshots** — automatic checkpointing at configurable intervals to avoid replaying entire streams.
 - **Passivation** — idle aggregates are shut down cleanly and will rehydrate from the store on the next command.
 
@@ -111,26 +111,67 @@ The store layer separates domain logic from persistence concerns through two beh
 
 #### Event Store
 
-The event store is the heart of event sourcing persistence, designed as a `behaviour` (`es_contract_event_store`) that backends implement. It guarantees **ordering** (events replayed in sequence), **atomicity** (all-or-nothing persistence), and **immutability** (events never modified).
+The event store is the heart of event sourcing persistence, designed as a `behaviour` (`es_contract_event_store`) that backends implement. It guarantees **ordering** (events replayed in sequence or global position order), **atomicity** (all-or-nothing persistence), and **immutability** (events never modified).
+
+Events carry a stream-local `sequence`, used to rebuild a single aggregate. Store backends also assign a monotonically increasing global `position` when events are persisted. This position is storage metadata, not part of the domain event map, and is used for global replay, projections, and future read-side subscriptions.
 
 **Required Callbacks:**
 
 ```erlang
 % Appends events to a stream with monotonic sequence ordering
--callback append(StreamId, Events) -> ok
+-callback append(StreamId, Events) -> ok | {error, Reason}
     when StreamId :: es_contract_event:stream_id(),
-         Events :: [es_contract_event:t()].
+         Events :: [es_contract_event:t()],
+         Reason :: term().
 
-% Replays events in sequence order, applying a fold function
--callback fold(StreamId, Fun, Acc0, Range) -> Acc1
+% Replays events for one stream in sequence order
+-callback fold(StreamId, FoldFun, Acc0, Range) ->
+    {ok, Acc1} | {error, Reason}
     when StreamId :: es_contract_event:stream_id(),
-         Fun :: fun((Event :: es_contract_event:t(), AccIn) -> AccOut),
+         FoldFun :: fun(
+             (Event :: es_contract_event:t(),
+              Sequence :: es_contract_event:sequence(),
+              AccIn) -> AccOut
+         ),
          Acc0 :: term(),
          Range :: es_contract_range:range(),
          Acc1 :: term(),
          AccIn :: term(),
-         AccOut :: term().
+         AccOut :: term(),
+         Reason :: term().
+
+% Replays all events across streams in global position order
+-callback fold_all(FoldFun, Acc0, Range) ->
+    {ok, Acc1} | {error, Reason}
+    when FoldFun :: fun(
+             (Event :: es_contract_event:t(),
+              Position :: es_contract_event_store:position(),
+              AccIn) -> AccOut
+         ),
+         Acc0 :: term(),
+         Range :: es_contract_range:range(),
+         Acc1 :: term(),
+         AccIn :: term(),
+         AccOut :: term(),
+         Reason :: term().
 ```
+
+`fold/4` is the aggregate replay primitive: it reads one stream using stream-local sequence ranges. `fold_all/3` is the read-side primitive: it reads the global event log using position ranges. The kernel wrapper also exposes `es_kernel_store:fold_all/4` when callers need to provide an explicit accumulator.
+
+#### Projections
+
+`es_contract_projection` defines the read-side projection behaviour:
+
+```erlang
+-callback init() -> projection_state().
+-callback name() -> atom().
+-callback handle_event(Event, State) -> {ok, NewState} | {error, Reason}.
+-callback event_filter(Event) -> boolean().
+```
+
+`event_filter/1` is optional. If omitted, the projection is interested in all events. Projection modules describe how to transform events into read-side state; they do not decide how events are consumed from the store.
+
+This release provides the projection contract and global event folding support. A supervised projection runner, checkpoint storage, and live subscription support are intentionally left for a later iteration.
 
 #### Snapshot Store
 
@@ -172,7 +213,8 @@ Setting `snapshot_interval => 0` (default) disables automatic snapshotting.
 
 #### Additional future features
 
-- Support event subscriptions for real-time updates.
+- Add a projection runner with checkpointed catch-up over the global event log.
+- Support optional event subscriptions for real-time read-side updates.
 - Implement snapshot retention policies (e.g., keep only last N snapshots).
 
 #### Backend roadmap

--- a/apps/es_kernel/src/es_contract_event.erl
+++ b/apps/es_kernel/src/es_contract_event.erl
@@ -47,7 +47,11 @@ across different aggregate types and instances.
 """.
 -type stream_id() :: {aggregate_type(), aggregate_id()}.
 
--doc "Sequence number of the event within its stream, starting from 0.".
+-doc """
+Sequence number of the event within its stream, starting from 0.
+
+Sequence values are monotonically increasing within a given stream.
+""".
 -type sequence() :: non_neg_integer().
 
 -doc "Type identifier for the event, describing what happened.".

--- a/apps/es_kernel/src/es_contract_event_store.erl
+++ b/apps/es_kernel/src/es_contract_event_store.erl
@@ -1,26 +1,29 @@
 -module(es_contract_event_store).
+
 -moduledoc """
-Behaviour for **event store backends**.
+Behaviour for event store backends.
 
 An event store backend is responsible for durable persistence and ordered retrieval
 of domain events. It defines the functional capabilities required to persist and
 retrieve events, independent of lifecycle management concerns.
 
 Callbacks:
-- `append/2` — append events to a stream, ensuring monotonic sequence numbers
-- `fold/4` — replay events in order and fold them with a user function
+- `append/2` - append events to a stream, ensuring monotonic sequence numbers
+- `fold/4` - replay events of a single stream in order and fold them with a user function
 
 Implementations must guarantee:
-- **ordering**: events for a given stream are stored and replayed in strictly increasing
+
+- ordering: events for a given stream are stored and replayed in strictly increasing
   sequence order
-- **atomicity**: either all or none of the events in a batch are persisted
-- **immutability**: persisted events must never be modified
+- atomicity: either all or none of the events in a batch are persisted
+- immutability: persisted events must never be modified
 
 Typical implementations include in-memory stores (ETS) and relational databases.
 
-Note: Backend implementations may provide `start/0` and `stop/0` functions for
+Note: backend implementations may provide `start/0` and `stop/0` functions for
 lifecycle management, but these are not part of this behaviour contract.
 """.
+
 -doc """
 Append events to an event stream.
 
@@ -28,38 +31,65 @@ This callback appends events to the specified stream, ensuring monotonic orderin
 by sequence number. Each event is durably persisted and becomes part of the immutable
 event log for the stream.
 
-- StreamId is an atom identifying the event stream (e.g., order-123).
-- Events is the list of events to append to the stream. The events provided are unique and all
-belong to the same stream.
+- StreamId identifies the event stream (for example `{order, <<"123">>}`).
+- Events is the list of events to append to the stream.
 
-Returns `ok` on success. May throw an exception if persistence fails (e.g., badarg if the
-stream ID is incorrect, duplicate events if the sequence number is not unique).
+The kernel guarantees that:
+
+- all events in the batch belong to the same stream
+- the `stream_id()` carried by each event is equal to `StreamId`
+
+Backends MAY rely on these invariants and are not required to re validate them.
+
+On success, implementations MUST return `ok`.
+
+On failure, implementations MUST return `{error, Reason}` and MUST guarantee that
+no partial batch is ever visible. Exceptions SHOULD be reserved for programmer
+errors or unrecoverable failures.
 """.
--callback append(StreamId, Events) -> ok when
+-callback append(StreamId, Events) ->
+    ok | {error, Reason}
+when
     StreamId :: es_contract_event:stream_id(),
-    Events :: [es_contract_event:t()].
+    Events :: [es_contract_event:t()],
+    Reason :: term().
+
 -doc """
-Retrieves events from a stream and folds them into an accumulator.
+Retrieves events from a single stream and folds them into an accumulator.
 
-This callback fetches events for the given `StreamId` within the specified `Range`,
-applies the `FoldFun` to each event in sequence order, and returns the final accumulator.
-It's typically used to rebuild application state by replaying events.
+This callback fetches events for the given `StreamId` within the specified sequence
+`Range`, applies `FoldFun` to each event in sequence order, and returns the final
+accumulator. It is typically used to rebuild aggregate state by replaying events.
 
-- StreamId is an atom identifying the event stream (e.g., order-123).
-- FoldFun is a function `fun((Event, AccIn) -> AccOut)` to process each event.
-- InitialAcc is the initial accumulator value (e.g., an empty state).
+- StreamId identifies the event stream.
+ - FoldFun is a function `fun((Event, Sequence, AccIn) -> AccOut)` to process each event
+   together with its sequence number in the stream.
+- InitialAcc is the initial accumulator value (for example an empty state).
 - Range is a sequence range defining which events to retrieve:
-  - Use `es_contract_range:new(0, infinity)` to replay all events.
-  - Use `es_contract_range:new(N, infinity)` to replay from checkpoint N.
-  - Use `es_contract_range:new(M, N)` to replay a specific bounded range.
+  - `es_contract_range:new(0, infinity)` to replay all events
+  - `es_contract_range:new(N, infinity)` to replay from sequence N
+  - `es_contract_range:new(M, N)` to replay a bounded sequence range
 
-Returns the final accumulator after folding all events in the range.
+If the range is empty, implementations MUST return `{ok, InitialAcc}`.
+
+On success, returns `{ok, Acc1}` where `Acc1` is the final accumulator.
+On failure, implementations MUST return `{error, Reason}`.
+Exceptions SHOULD be reserved for programmer errors or unrecoverable failures.
 """.
--callback fold(StreamId, Fun, Acc0, Range) -> Acc1 when
+-callback fold(StreamId, FoldFun, Acc0, Range) ->
+    {ok, Acc1} | {error, Reason}
+when
     StreamId :: es_contract_event:stream_id(),
-    Fun :: fun((Event :: es_contract_event:t(), AccIn) -> AccOut),
+    FoldFun :: fun(
+        (
+            Event :: es_contract_event:t(),
+            Sequence :: es_contract_event:sequence(),
+            AccIn
+        ) -> AccOut
+    ),
     Acc0 :: term(),
     Range :: es_contract_range:range(),
     Acc1 :: term(),
     AccIn :: term(),
-    AccOut :: term().
+    AccOut :: term(),
+    Reason :: term().

--- a/apps/es_kernel/src/es_contract_event_store.erl
+++ b/apps/es_kernel/src/es_contract_event_store.erl
@@ -1,5 +1,15 @@
 -module(es_contract_event_store).
 
+-export_type([position/0]).
+
+-doc """
+Global position of an event in the event store log.
+
+Positions are assigned by storage backends and are not part of the domain event
+payload. They are monotonically increasing within a backend instance.
+""".
+-type position() :: non_neg_integer().
+
 -moduledoc """
 Behaviour for event store backends.
 
@@ -10,6 +20,7 @@ retrieve events, independent of lifecycle management concerns.
 Callbacks:
 - `append/2` - append events to a stream, ensuring monotonic sequence numbers
 - `fold/4` - replay events of a single stream in order and fold them with a user function
+- `fold_all/3` - replay events from the global event log in position order and fold them
 
 Implementations must guarantee:
 
@@ -53,7 +64,6 @@ when
     StreamId :: es_contract_event:stream_id(),
     Events :: [es_contract_event:t()],
     Reason :: term().
-
 -doc """
 Retrieves events from a single stream and folds them into an accumulator.
 
@@ -88,6 +98,51 @@ when
         ) -> AccOut
     ),
     Acc0 :: term(),
+    Range :: es_contract_range:range(),
+    Acc1 :: term(),
+    AccIn :: term(),
+    AccOut :: term(),
+    Reason :: term().
+
+-doc """
+Retrieves events from the global event log and folds them into an accumulator.
+
+This callback is intended for projections and subscriptions on the read side
+of a CQRS architecture. Unlike `fold/4`, which operates on a single stream
+and uses sequence ranges, this function operates on the global event log and
+uses position ranges.
+
+Each persisted event is assigned a monotonically increasing global position
+(offset) when written. This position enables:
+
+- catch-up subscriptions (replay from position N)
+- projection checkpointing (resume processing from last position)
+- global event ordering for read models
+- cross-aggregate queries
+
+- FoldFun is a function `fun((Event, Position, AccIn) -> AccOut)` to process
+  each event with its global position.
+- InitialAcc is the initial accumulator value.
+- Range is a position range (not a sequence range) defining which events to retrieve.
+  Implementations MUST interpret this range in terms of global positions.
+
+
+On success, returns `{ok, Acc1}` where `Acc1` is the final accumulator.
+On failure, implementations MUST return `{error, Reason}`.
+Exceptions SHOULD be reserved for programmer errors or unrecoverable failures.
+""".
+-callback fold_all(FoldFun, Acc0, Range) ->
+    {ok, Acc1} | {error, Reason}
+when
+    FoldFun :: fun(
+        (
+            Event :: es_contract_event:t(),
+            Position :: position(),
+            AccIn
+        ) -> AccOut
+    ),
+    Acc0 :: term(),
+    %% position-based range
     Range :: es_contract_range:range(),
     Acc1 :: term(),
     AccIn :: term(),

--- a/apps/es_kernel/src/es_contract_projection.erl
+++ b/apps/es_kernel/src/es_contract_projection.erl
@@ -52,7 +52,6 @@ event_filter(_) -> false.
 
 -export_type([projection_state/0, event_filter/0]).
 
-
 -type projection_state() :: term().
 
 -doc """

--- a/apps/es_kernel/src/es_contract_projection.erl
+++ b/apps/es_kernel/src/es_contract_projection.erl
@@ -1,0 +1,141 @@
+-module(es_contract_projection).
+-moduledoc """
+Defines the projection behaviour for building read models from event streams.
+
+Modules implementing this behaviour encapsulate the logic for consuming
+events and maintaining derived state (read models, materialized views, etc.).
+Projections are the read-side of a CQRS architecture, complementing the
+write-side aggregates.
+
+Projections are event handlers that:
+- Process events in order to build read-optimized views
+- Maintain their own state independent of aggregates
+- Can subscribe to specific event streams or all events
+- Track their position in the event stream for resumability
+
+Implementers are responsible for:
+
+- Initializing projection state (`init/0`)
+- Processing events and updating state (`handle_event/2`)
+- Providing a unique projection identifier (`name/0`)
+- Optionally filtering events to process (`event_filter/1`)
+
+## Example
+
+```erlang
+-module(account_balance_projection).
+-behaviour(es_contract_projection).
+
+-export([init/0, handle_event/2, name/0, event_filter/1]).
+
+init() ->
+    #{balances => #{}}.
+
+handle_event(#{type := deposited, payload := #{account_id := Id, amount := Amount}},
+             #{balances := Balances} = State) ->
+    CurrentBalance = maps:get(Id, Balances, 0),
+    {ok, State#{balances => Balances#{Id => CurrentBalance + Amount}}};
+handle_event(#{type := withdrawn, payload := #{account_id := Id, amount := Amount}},
+             #{balances := Balances} = State) ->
+    CurrentBalance = maps:get(Id, Balances, 0),
+    {ok, State#{balances => Balances#{Id => CurrentBalance - Amount}}};
+handle_event(_Event, State) ->
+    {ok, State}.
+
+name() ->
+    account_balance_projection.
+
+event_filter(#{aggregate_type := account}) -> true;
+event_filter(_) -> false.
+```
+""".
+
+-export_type([projection_state/0, event_filter/0]).
+
+
+-type projection_state() :: term().
+
+-doc """
+Predicate function that determines whether an event should be processed.
+
+Returns `true` if the event should be handled, `false` to skip it.
+""".
+-type event_filter() :: fun((es_contract_event:t()) -> boolean()).
+
+-doc """
+Initialize the projection's state.
+
+This is called once when the projection process is started and before
+any events have been processed.
+
+Returns the initial projection state.
+""".
+-callback init() -> projection_state().
+
+-doc """
+Return the unique name for this projection.
+
+This name is used to:
+- Identify the projection in the system
+- Track checkpoint position for resumability
+- Register the projection in the manager
+
+The name must be unique across all projections in the system and should
+be stable across restarts.
+
+Returns a unique atom identifier for this projection.
+""".
+-callback name() -> atom().
+
+-doc """
+Process an event and update the projection state.
+
+This function is called for each event that passes the filter (if defined).
+It receives the current projection state and returns either:
+
+- `{ok, NewState}` — The updated projection state
+- `{error, Reason}` — An error occurred processing the event
+
+This function should be deterministic for idempotency. Since events may be
+replayed during recovery or reprocessed due to failures, the projection
+should handle duplicate events gracefully.
+
+Side effects (database writes, external API calls, etc.) are allowed here,
+unlike in aggregate callbacks. However, consider idempotency carefully.
+
+- Event is the domain event to process
+- State is the current projection state
+
+Returns the result of processing the event.
+""".
+-callback handle_event(Event, State) ->
+    {ok, NewState} | {error, Reason}
+when
+    Event :: es_contract_event:t(),
+    State :: projection_state(),
+    NewState :: projection_state(),
+    Reason :: term().
+
+-doc """
+Filter events to determine which ones this projection should process.
+
+This optional callback allows projections to subscribe to a subset of events
+rather than all events in the system. If not implemented, the projection
+will process all events.
+
+Common filtering strategies:
+- By aggregate type: `#{aggregate_type := account} -> true`
+- By event type: `#{type := user_created} -> true`
+- By stream pattern: `#{stream_id := {user, _}} -> true`
+- By tags: Check if event has specific tags
+- Combined criteria: Multiple conditions
+
+Returns `true` if the event should be processed, `false` to skip it.
+
+Note: This is an optional callback. If not implemented, all events are processed.
+""".
+-callback event_filter(Event) -> ShouldProcess when
+    Event :: es_contract_event:t(),
+    ShouldProcess :: boolean().
+
+-optional_callbacks([event_filter/1]).

--- a/apps/es_kernel/src/es_kernel_aggregate.erl
+++ b/apps/es_kernel/src/es_kernel_aggregate.erl
@@ -158,19 +158,24 @@ rehydrate(AggregateModule, StoreContext, StreamId) ->
                 {State0, ?SEQUENCE_ZERO}
         end,
     FoldFun =
-        fun(#{payload := Payload, sequence := Seq}, {StateAcc, _SeqAcc}) ->
+        fun(#{payload := Payload}, Seq, {StateAcc, _SeqAcc}) ->
             {
                 AggregateModule:apply_event(Payload, StateAcc),
                 Seq
             }
         end,
-    es_kernel_store:fold(
-        StoreContext,
-        StreamId,
-        FoldFun,
-        {StateFromSnapshot, SequenceFromSnapshot},
-        es_contract_range:new(SequenceFromSnapshot + 1, infinity)
-    ).
+    case
+        es_kernel_store:fold(
+            StoreContext,
+            StreamId,
+            FoldFun,
+            {StateFromSnapshot, SequenceFromSnapshot},
+            es_contract_range:new(SequenceFromSnapshot + 1, infinity)
+        )
+    of
+        {ok, Result} -> Result;
+        {error, Reason} -> erlang:error(Reason)
+    end.
 
 -doc """
 Handles synchronous commands sent to the aggregate.

--- a/apps/es_kernel/src/es_kernel_store.erl
+++ b/apps/es_kernel/src/es_kernel_store.erl
@@ -34,10 +34,11 @@ This is the primary mechanism for persisting domain events. All events in the li
 must target the same stream and have unique identifiers. The store backend ensures
 atomic persistence and maintains sequence ordering.
 """.
--spec append(StoreContext, StreamId, Events) -> ok when
+-spec append(StoreContext, StreamId, Events) -> ok | {error, Reason} when
     StoreContext :: store_context(),
     StreamId :: es_contract_event:stream_id(),
-    Events :: [es_contract_event:t()].
+    Events :: [es_contract_event:t()],
+    Reason :: term().
 append({EventModule, _}, StreamId, Events) when is_list(Events) ->
     %% Validate that all events target the same StreamId
     ok = lists:foreach(
@@ -56,12 +57,10 @@ append({EventModule, _}, StreamId, Events) when is_list(Events) ->
     SeenIds = [es_contract_event:key(E) || E <- Events],
     case length(SeenIds) =:= length(lists:usort(SeenIds)) of
         true ->
-            ok;
+            EventModule:append(StreamId, Events);
         false ->
-            erlang:error(duplicate_event)
-    end,
-
-    EventModule:append(StreamId, Events).
+            {error, duplicate_event}
+    end.
 
 -doc """
 Folds events from the event store into an accumulator using the specified persistence module.
@@ -69,15 +68,22 @@ Folds events from the event store into an accumulator using the specified persis
 This is the core operation for event replay and state reconstruction. The backend
 retrieves events within the specified range and applies the fold function in sequence order.
 """.
--spec fold(StoreContext, StreamId, Fun, Acc0, Range) -> Acc1 when
+-spec fold(StoreContext, StreamId, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
     StoreContext :: store_context(),
     StreamId :: es_contract_event:stream_id(),
-    Fun :: fun((Event :: es_contract_event:t(), AccIn) -> AccOut),
+    Fun :: fun(
+        (
+            Event :: es_contract_event:t(),
+            Sequence :: es_contract_event:sequence(),
+            AccIn
+        ) -> AccOut
+    ),
     Acc0 :: term(),
     Range :: es_contract_range:range(),
     Acc1 :: term(),
     AccIn :: term(),
-    AccOut :: term().
+    AccOut :: term(),
+    Reason :: term().
 fold({EventModule, _}, StreamId, Fun, InitialResult, Range) ->
     EventModule:fold(StreamId, Fun, InitialResult, Range).
 
@@ -92,15 +98,18 @@ This is a convenience wrapper around fold/5 that collects all events into a list
     Range :: es_contract_range:range(),
     Result :: [es_contract_event:t()].
 retrieve_events(StoreContext, StreamId, Range) ->
-    lists:reverse(
+    case
         fold(
             StoreContext,
             StreamId,
-            fun(Event, Acc) -> [Event | Acc] end,
+            fun(Event, _Seq, Acc) -> [Event | Acc] end,
             [],
             Range
         )
-    ).
+    of
+        {ok, Events} -> lists:reverse(Events);
+        {error, Reason} -> erlang:error(Reason)
+    end.
 
 -doc """
 Creates a new event map.

--- a/apps/es_kernel/src/es_kernel_store.erl
+++ b/apps/es_kernel/src/es_kernel_store.erl
@@ -14,6 +14,8 @@ Both may be the same module if it implements both event and snapshot storage.
 -export([
     append/3,
     fold/5,
+    fold_all/3,
+    fold_all/4,
     retrieve_events/3,
     store/2,
     load_latest/2,
@@ -86,6 +88,39 @@ retrieves events within the specified range and applies the fold function in seq
     Reason :: term().
 fold({EventModule, _}, StreamId, Fun, InitialResult, Range) ->
     EventModule:fold(StreamId, Fun, InitialResult, Range).
+
+-doc """
+Folds all events across all streams into an accumulator using the specified persistence module.
+
+The backend retrieves events globally, ordered by their assigned positions, and applies the
+fold function.
+""".
+-spec fold_all(StoreContext, Fun, Range) -> {ok, Acc1} | {error, Reason} when
+    StoreContext :: store_context(),
+    Fun :: fun(
+        (Event :: es_contract_event:t(), Position :: es_contract_event_store:position(), AccIn) -> AccOut
+    ),
+    Range :: es_contract_range:range(),
+    Acc1 :: term(),
+    AccIn :: term(),
+    AccOut :: term(),
+    Reason :: term().
+fold_all({EventModule, _}, Fun, Range) ->
+    EventModule:fold_all(Fun, #{}, Range).
+
+-spec fold_all(StoreContext, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
+    StoreContext :: store_context(),
+    Fun :: fun(
+        (Event :: es_contract_event:t(), Position :: es_contract_event_store:position(), AccIn) -> AccOut
+    ),
+    Acc0 :: term(),
+    Range :: es_contract_range:range(),
+    Acc1 :: term(),
+    AccIn :: term(),
+    AccOut :: term(),
+    Reason :: term().
+fold_all({EventModule, _}, Fun, InitialResult, Range) ->
+    EventModule:fold_all(Fun, InitialResult, Range).
 
 -doc """
 Retrieves events for a given stream using the specified store module and range.

--- a/apps/es_kernel/src/es_kernel_store.erl
+++ b/apps/es_kernel/src/es_kernel_store.erl
@@ -98,7 +98,11 @@ fold function.
 -spec fold_all(StoreContext, Fun, Range) -> {ok, Acc1} | {error, Reason} when
     StoreContext :: store_context(),
     Fun :: fun(
-        (Event :: es_contract_event:t(), Position :: es_contract_event_store:position(), AccIn) -> AccOut
+        (
+            Event :: es_contract_event:t(),
+            Position :: es_contract_event_store:position(),
+            AccIn
+        ) -> AccOut
     ),
     Range :: es_contract_range:range(),
     Acc1 :: term(),
@@ -111,7 +115,11 @@ fold_all({EventModule, _}, Fun, Range) ->
 -spec fold_all(StoreContext, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
     StoreContext :: store_context(),
     Fun :: fun(
-        (Event :: es_contract_event:t(), Position :: es_contract_event_store:position(), AccIn) -> AccOut
+        (
+            Event :: es_contract_event:t(),
+            Position :: es_contract_event_store:position(),
+            AccIn
+        ) -> AccOut
     ),
     Acc0 :: term(),
     Range :: es_contract_range:range(),

--- a/apps/es_kernel/test/es_kernel_store_tests.erl
+++ b/apps/es_kernel/test/es_kernel_store_tests.erl
@@ -13,6 +13,8 @@ suite_test_() ->
         [
             {"persist_single_event", fun persist_single_event/1},
             {"persist_2_streams_event", fun persist_2_streams_event/1},
+            {"fold_all_events", fun fold_all_events/1},
+            {"fold_all_range", fun fold_all_range/1},
             {"fetch_streams_event", fun fetch_streams_event/1},
             {"wrong_stream_id", fun wrong_stream_id/1},
             {"duplicate_event", fun duplicate_event/1},
@@ -122,6 +124,55 @@ persist_2_streams_event(Store) ->
         es_kernel_store:retrieve_events(
             Store, ?STREAM_B, es_contract_range:new(0, infinity)
         )
+    ),
+    ?assertEqual(ok, stop_store(Store)).
+
+fold_all_events(Store) ->
+    start_store(Store),
+    Timestamp = erlang:system_time(),
+    EventA1 = es_kernel_store:new_event(
+        ?STREAM_A, user, user_registered, 1, Timestamp, {"John Doe"}
+    ),
+    EventB1 = es_kernel_store:new_event(
+        ?STREAM_B, user, user_registered, 1, Timestamp, {"Jane Doe"}
+    ),
+    EventA2 = es_kernel_store:new_event(
+        ?STREAM_A, user, user_updated, 2, Timestamp, {"John Smith"}
+    ),
+
+    ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_A, [EventA1])),
+    ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_B, [EventB1])),
+    ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_A, [EventA2])),
+
+    FoldFun = fun(Event, Position, Acc) -> Acc ++ [{Position, Event}] end,
+    ?assertMatch(
+        {ok, [{0, EventA1}, {1, EventB1}, {2, EventA2}]},
+        es_kernel_store:fold_all(Store, FoldFun, [], es_contract_range:new(0, infinity))
+    ),
+    ?assertNot(maps:is_key(position, EventA1)),
+    ?assertEqual(ok, stop_store(Store)).
+
+fold_all_range(Store) ->
+    start_store(Store),
+    Timestamp = erlang:system_time(),
+    EventA1 = es_kernel_store:new_event(
+        ?STREAM_A, user, user_registered, 1, Timestamp, {"John Doe"}
+    ),
+    EventB1 = es_kernel_store:new_event(
+        ?STREAM_B, user, user_registered, 1, Timestamp, {"Jane Doe"}
+    ),
+    EventA2 = es_kernel_store:new_event(
+        ?STREAM_A, user, user_updated, 2, Timestamp, {"John Smith"}
+    ),
+
+    ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_A, [EventA1])),
+    ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_B, [EventB1])),
+    ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_A, [EventA2])),
+
+    FoldFun = fun(Event, Position, Acc) -> Acc ++ [{Position, Event}] end,
+    ?assertMatch(
+        {ok, [{1, EventB1}, {2, EventA2}]},
+        es_kernel_store:fold_all(Store, FoldFun, [], es_contract_range:new(1, 3))
     ),
     ?assertEqual(ok, stop_store(Store)).
 

--- a/apps/es_kernel/test/es_kernel_store_tests.erl
+++ b/apps/es_kernel/test/es_kernel_store_tests.erl
@@ -4,11 +4,12 @@
 
 -define(ETS_STORE_CONTEXT, {es_store_ets, es_store_ets}).
 -define(MNESIA_STORE_CONTEXT, {es_store_mnesia, es_store_mnesia}).
+-define(FILE_STORE_CONTEXT, {es_store_file, es_store_file}).
 -define(STREAM_A, {user, <<"account-A">>}).
 -define(STREAM_B, {user, <<"account-B">>}).
 
 suite_test_() ->
-    Stores = [?MNESIA_STORE_CONTEXT, ?ETS_STORE_CONTEXT],
+    Stores = [?MNESIA_STORE_CONTEXT, ?ETS_STORE_CONTEXT, ?FILE_STORE_CONTEXT],
     BaseTests =
         [
             {"persist_single_event", fun persist_single_event/1},
@@ -35,10 +36,19 @@ suite_test_() ->
 
 setup() ->
     mnesia:start(),
-    ok.
+    RootDir = filename:join([
+        "_build",
+        "test",
+        "es_store_file",
+        integer_to_list(erlang:unique_integer([positive]))
+    ]),
+    application:set_env(es_store_file, root_dir, RootDir),
+    RootDir.
 
-teardown(_) ->
+teardown(RootDir) ->
     mnesia:stop(),
+    application:unset_env(es_store_file, root_dir),
+    _ = file:del_dir_r(RootDir),
     ok.
 
 %%% Helper functions
@@ -477,6 +487,20 @@ snapshot_save_error(?MNESIA_STORE_CONTEXT = Store) ->
     Snapshot = es_kernel_store:new_snapshot(Domain, ?STREAM_A, Sequence, Timestamp, State),
 
     %% Normal save should still return ok
+    ?assertMatch(ok, es_kernel_store:store(Store, Snapshot)),
+
+    ?assertEqual(ok, stop_store(Store));
+snapshot_save_error(?FILE_STORE_CONTEXT = Store) ->
+    %% For the file store, stop/0 is intentionally a no-op. Verify the
+    %% snapshot write path remains successful for this backend.
+    ?assertMatch(ok, start_store(Store)),
+
+    Timestamp = erlang:system_time(),
+    State = #{balance => 100},
+    Sequence = 5,
+    Domain = user,
+
+    Snapshot = es_kernel_store:new_snapshot(Domain, ?STREAM_A, Sequence, Timestamp, State),
     ?assertMatch(ok, es_kernel_store:store(Store, Snapshot)),
 
     ?assertEqual(ok, stop_store(Store)).

--- a/apps/es_kernel/test/es_kernel_store_tests.erl
+++ b/apps/es_kernel/test/es_kernel_store_tests.erl
@@ -250,9 +250,8 @@ duplicate_event(Store) ->
         ),
 
     ?assertMatch(ok, es_kernel_store:append(Store, ?STREAM_A, [Event])),
-    ?assertException(
-        error,
-        duplicate_event,
+    ?assertMatch(
+        {error, duplicate_event},
         es_kernel_store:append(Store, ?STREAM_A, [Event])
     ),
     ?assertMatch(
@@ -289,9 +288,8 @@ duplicate_event(Store) ->
             )
         ],
 
-    ?assertException(
-        error,
-        duplicate_event,
+    ?assertMatch(
+        {error, duplicate_event},
         es_kernel_store:append(Store, ?STREAM_B, Events)
     ),
     ?assertMatch(

--- a/apps/es_store_ets/src/es_store_ets.erl
+++ b/apps/es_store_ets/src/es_store_ets.erl
@@ -10,6 +10,7 @@ The ETS-based implementation of the event store.
     start/0,
     stop/0,
     fold/4,
+    fold_all/3,
     append/2,
     store/1,
     load_latest/1
@@ -28,7 +29,11 @@ The ETS-based implementation of the event store.
 -type snapshot_data() :: es_contract_snapshot:state().
 
 -record(event_record, {
-    key :: event_id(), stream_id :: stream_id(), sequence :: sequence(), event :: event()
+    key :: event_id(),
+    stream_id :: stream_id(),
+    sequence :: sequence(),
+    position :: es_contract_event_store:position(),
+    event :: event()
 }).
 
 -record(snapshot_record, {
@@ -40,11 +45,13 @@ The ETS-based implementation of the event store.
 
 -define(DEFAULT_EVENT_TABLE_NAME, events).
 -define(DEFAULT_SNAPSHOT_TABLE_NAME, snapshots).
+-define(DEFAULT_POSITION_COUNTER_TABLE_NAME, position_counter).
 
 -spec start() -> ok.
 start() ->
     EventTable = event_table_name(),
     SnapshotTable = snapshot_table_name(),
+    PositionCounterTable = position_counter_table_name(),
     case ets:info(EventTable) of
         undefined ->
             _ = ets:new(
@@ -64,21 +71,47 @@ start() ->
             ok;
         _ ->
             ok
+    end,
+    case ets:info(PositionCounterTable) of
+        undefined ->
+            _ = ets:new(
+                PositionCounterTable,
+                [set, named_table, public]
+            ),
+            %% Initialize global position counter to 0
+            ets:insert(PositionCounterTable, {global_position, 0}),
+            ok;
+        _ ->
+            ok
     end.
 
 -spec stop() -> ok.
 stop() ->
     ets:delete(event_table_name()),
     ets:delete(snapshot_table_name()),
+    ets:delete(position_counter_table_name()),
     ok.
 
 -spec append(StreamId, Events) -> ok | {error, Reason} when
     StreamId :: stream_id(),
     Events :: [event()],
     Reason :: term().
+append(_, []) ->
+    ok;
 append(_, Events) ->
-    Records = lists:map(fun event_to_record/1, Events),
-    case ets:insert_new(event_table_name(), Records) of
+    %% Assign global positions to events
+    PositionCounterTable = position_counter_table_name(),
+    NumEvents = length(Events),
+    StartPosition = ets:update_counter(PositionCounterTable, global_position, NumEvents),
+    BasePosition = StartPosition - NumEvents,
+    RecordsWithPositions = lists:zipwith(
+        fun(Event, Offset) ->
+            event_to_record(Event, BasePosition + Offset)
+        end,
+        Events,
+        lists:seq(0, NumEvents - 1)
+    ),
+    case ets:insert_new(event_table_name(), RecordsWithPositions) of
         true ->
             ok;
         false ->
@@ -107,14 +140,15 @@ fold(StreamId, FoldFun, InitialAcc, Range) when
         From = es_contract_range:lower_bound(Range),
         To = es_contract_range:upper_bound(Range),
 
-        Pattern = {event_record, '_', StreamId, '$1', '$2'},
+        Pattern = {event_record, '_', StreamId, '$1', '_', '$2'},
         Guard = [{'>=', '$1', From}, {'<', '$1', To}],
         MatchSpec = [{Pattern, Guard, [{{'$1', '$2'}}]}],
         ResultPairs = ets:select(event_table_name(), MatchSpec),
+        SortedPairs = lists:sort(ResultPairs),
         Result = lists:foldl(
             fun({Seq, Event}, Acc) -> FoldFun(Event, Seq, Acc) end,
             InitialAcc,
-            ResultPairs
+            SortedPairs
         ),
         {ok, Result}
     catch
@@ -122,11 +156,12 @@ fold(StreamId, FoldFun, InitialAcc, Range) when
             {error, {Class, Reason, Stacktrace}}
     end.
 
-event_to_record(Event) ->
+event_to_record(Event, Position) ->
     #event_record{
         key = es_contract_event:key(Event),
         stream_id = maps:get(stream_id, Event),
         sequence = maps:get(sequence, Event),
+        position = Position,
         event = Event
     }.
 
@@ -161,6 +196,36 @@ load_latest(StreamId) ->
             {error, not_found}
     end.
 
+-spec fold_all(Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
+    Fun :: fun((Event :: event(), Position :: es_contract_event_store:position(), AccIn) -> AccOut),
+    Acc0 :: term(),
+    Range :: es_contract_range:range(),
+    Acc1 :: term(),
+    AccIn :: term(),
+    AccOut :: term(),
+    Reason :: term().
+fold_all(FoldFun, InitialAcc, Range) when is_function(FoldFun, 3) ->
+    try
+        From = es_contract_range:lower_bound(Range),
+        To = es_contract_range:upper_bound(Range),
+        Pattern = {event_record, '_', '_', '_', '$1', '$2'},
+        Guard = [{'>=', '$1', From}, {'<', '$1', To}],
+        MatchSpec = [{Pattern, Guard, [{{'$1', '$2'}}]}],
+        Results = ets:select(event_table_name(), MatchSpec),
+        Sorted = lists:sort(Results),
+        Result = lists:foldl(
+            fun({Position, Event}, Acc) ->
+                FoldFun(Event, Position, Acc)
+            end,
+            InitialAcc,
+            Sorted
+        ),
+        {ok, Result}
+    catch
+        Class:Reason:Stacktrace ->
+            {error, {Class, Reason, Stacktrace}}
+    end.
+
 -spec event_table_name() -> atom().
 event_table_name() ->
     application:get_env(es_store_ets, event_table_name, ?DEFAULT_EVENT_TABLE_NAME).
@@ -168,3 +233,9 @@ event_table_name() ->
 -spec snapshot_table_name() -> atom().
 snapshot_table_name() ->
     application:get_env(es_store_ets, snapshot_table_name, ?DEFAULT_SNAPSHOT_TABLE_NAME).
+
+-spec position_counter_table_name() -> atom().
+position_counter_table_name() ->
+    application:get_env(
+        es_store_ets, position_counter_table_name, ?DEFAULT_POSITION_COUNTER_TABLE_NAME
+    ).

--- a/apps/es_store_ets/src/es_store_ets.erl
+++ b/apps/es_store_ets/src/es_store_ets.erl
@@ -72,37 +72,55 @@ stop() ->
     ets:delete(snapshot_table_name()),
     ok.
 
--spec append(StreamId, Events) -> ok when
+-spec append(StreamId, Events) -> ok | {error, Reason} when
     StreamId :: stream_id(),
-    Events :: [event()].
+    Events :: [event()],
+    Reason :: term().
 append(_, Events) ->
     Records = lists:map(fun event_to_record/1, Events),
     case ets:insert_new(event_table_name(), Records) of
         true ->
             ok;
         false ->
-            erlang:error(duplicate_event)
+            {error, duplicate_event}
     end.
 
--spec fold(StreamId, Fun, Acc0, Range) -> Acc1 when
+-spec fold(StreamId, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
     StreamId :: stream_id(),
-    Fun :: fun((Event :: event(), AccIn) -> AccOut),
+    Fun :: fun(
+        (
+            Event :: event(),
+            Sequence :: sequence(),
+            AccIn
+        ) -> AccOut
+    ),
     Acc0 :: term(),
     Range :: es_contract_range:range(),
     Acc1 :: term(),
     AccIn :: term(),
-    AccOut :: term().
+    AccOut :: term(),
+    Reason :: term().
 fold(StreamId, FoldFun, InitialAcc, Range) when
-    is_function(FoldFun, 2)
+    is_function(FoldFun, 3)
 ->
-    From = es_contract_range:lower_bound(Range),
-    To = es_contract_range:upper_bound(Range),
+    try
+        From = es_contract_range:lower_bound(Range),
+        To = es_contract_range:upper_bound(Range),
 
-    Pattern = {event_record, '_', StreamId, '$1', '$2'},
-    Guard = [{'>=', '$1', From}, {'<', '$1', To}],
-    MatchSpec = [{Pattern, Guard, ['$2']}],
-    ResultEvents = ets:select(event_table_name(), MatchSpec),
-    lists:foldl(FoldFun, InitialAcc, ResultEvents).
+        Pattern = {event_record, '_', StreamId, '$1', '$2'},
+        Guard = [{'>=', '$1', From}, {'<', '$1', To}],
+        MatchSpec = [{Pattern, Guard, [{{'$1', '$2'}}]}],
+        ResultPairs = ets:select(event_table_name(), MatchSpec),
+        Result = lists:foldl(
+            fun({Seq, Event}, Acc) -> FoldFun(Event, Seq, Acc) end,
+            InitialAcc,
+            ResultPairs
+        ),
+        {ok, Result}
+    catch
+        Class:Reason:Stacktrace ->
+            {error, {Class, Reason, Stacktrace}}
+    end.
 
 event_to_record(Event) ->
     #event_record{

--- a/apps/es_store_file/src/es_store_file.erl
+++ b/apps/es_store_file/src/es_store_file.erl
@@ -44,28 +44,43 @@ start() ->
 stop() ->
     ok.
 
--spec append(StreamId, Events) -> ok when
+-spec append(StreamId, Events) -> ok | {error, Reason} when
     StreamId :: stream_id(),
-    Events :: [event()].
+    Events :: [event()],
+    Reason :: term().
 append(_StreamId, []) ->
     ok;
 append(StreamId, [#{aggregate_type := AggregateType} | _] = Events) ->
     BaseName = stream_basename(AggregateType, StreamId),
     Path = event_file_path(BaseName),
     ensure_dir(events_dir()),
-    ensure_unique(Path, Events),
-    persist_events(Path, Events).
+    case ensure_unique(Path, Events) of
+        ok ->
+            case persist_events(Path, Events) of
+                ok -> ok;
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
--spec fold(StreamId, Fun, Acc0, Range) -> Acc1 when
+-spec fold(StreamId, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
     StreamId :: stream_id(),
-    Fun :: fun((Event :: event(), AccIn) -> AccOut),
+    Fun :: fun(
+        (
+            Event :: event(),
+            Sequence :: sequence(),
+            AccIn
+        ) -> AccOut
+    ),
     Acc0 :: term(),
     Range :: es_contract_range:range(),
     Acc1 :: term(),
     AccIn :: term(),
-    AccOut :: term().
+    AccOut :: term(),
+    Reason :: term().
 fold(StreamId, FoldFun, InitialAcc, Range) when
-    is_function(FoldFun, 2)
+    is_function(FoldFun, 3)
 ->
     From = es_contract_range:lower_bound(Range),
     To = es_contract_range:upper_bound(Range),
@@ -77,14 +92,19 @@ fold(StreamId, FoldFun, InitialAcc, Range) when
                 #{sequence := Seq} <- [E],
                 within_range(Seq, From, To)
             ],
-            lists:foldl(FoldFun, InitialAcc, Filtered);
+            Result = lists:foldl(
+                fun(#{sequence := Seq} = Event, Acc) -> FoldFun(Event, Seq, Acc) end,
+                InitialAcc,
+                Filtered
+            ),
+            {ok, Result};
         {error, not_found} ->
-            InitialAcc;
+            {ok, InitialAcc};
         {error, Reason} ->
-            erlang:error(Reason)
+            {error, Reason}
     end.
 
--spec ensure_unique(file:filename(), [event()]) -> ok.
+-spec ensure_unique(file:filename(), [event()]) -> ok | {error, term()}.
 ensure_unique(Path, Events) ->
     case read_terms(Path) of
         {ok, Existing} ->
@@ -95,24 +115,24 @@ ensure_unique(Path, Events) ->
                 )
             of
                 true ->
-                    erlang:error(duplicate_event);
+                    {error, duplicate_event};
                 false ->
                     ok
             end;
         {error, not_found} ->
             ok;
         {error, Reason} ->
-            erlang:error(Reason)
+            {error, Reason}
     end.
 
--spec persist_events(file:filename(), [event()]) -> ok.
+-spec persist_events(file:filename(), [event()]) -> ok | {error, term()}.
 persist_events(Path, Events) ->
     IoData = [serialize_to_line(E) || E <- Events],
     case file:write_file(Path, IoData, [append]) of
         ok ->
             ok;
         {error, Reason} ->
-            erlang:error(Reason)
+            {error, Reason}
     end.
 
 -spec serialize_to_line(event() | snapshot()) -> iolist().

--- a/apps/es_store_file/src/es_store_file.erl
+++ b/apps/es_store_file/src/es_store_file.erl
@@ -13,6 +13,7 @@ configurable root directory.
     start/0,
     stop/0,
     fold/4,
+    fold_all/3,
     append/2,
     store/1,
     load_latest/1
@@ -34,11 +35,14 @@ configurable root directory.
 -define(SNAPSHOTS_SUBDIR, "snapshots").
 -define(EVENT_EXT, ".log").
 -define(SNAPSHOT_EXT, ".snap").
+-define(POSITION_COUNTER_FILE, "position_counter").
+-define(GLOBAL_INDEX_FILE, "global_index.dat").
 
 -spec start() -> ok.
 start() ->
     ok = ensure_dir(events_dir()),
-    ok = ensure_dir(snapshots_dir()).
+    ok = ensure_dir(snapshots_dir()),
+    ok = ensure_position_counter().
 
 -spec stop() -> ok.
 stop() ->
@@ -57,8 +61,15 @@ append(StreamId, [#{aggregate_type := AggregateType} | _] = Events) ->
     case ensure_unique(Path, Events) of
         ok ->
             case persist_events(Path, Events) of
-                ok -> ok;
-                {error, Reason} -> {error, Reason}
+                ok ->
+                    NumEvents = length(Events),
+                    StartPosition = allocate_positions(NumEvents),
+                    EventsWithPositions = lists:zip(
+                        Events, lists:seq(StartPosition, StartPosition + NumEvents - 1)
+                    ),
+                    append_to_global_index(EventsWithPositions, Path);
+                {error, Reason} ->
+                    {error, Reason}
             end;
         {error, Reason} ->
             {error, Reason}
@@ -291,3 +302,111 @@ to_string(Value) when is_binary(Value) ->
     binary_to_list(Value);
 to_string(Value) when is_atom(Value) ->
     atom_to_list(Value).
+
+%% Position counter and global index management
+
+-spec ensure_position_counter() -> ok.
+ensure_position_counter() ->
+    Path = position_counter_path(),
+    case filelib:is_file(Path) of
+        true ->
+            ok;
+        false ->
+            ensure_dir(root_dir()),
+            file:write_file(Path, term_to_binary(0))
+    end.
+
+-spec allocate_positions(non_neg_integer()) -> es_contract_event_store:position().
+allocate_positions(NumEvents) ->
+    Path = position_counter_path(),
+    {ok, Binary} = file:read_file(Path),
+    CurrentPosition = binary_to_term(Binary),
+    NewPosition = CurrentPosition + NumEvents,
+    ok = file:write_file(Path, term_to_binary(NewPosition)),
+    CurrentPosition.
+
+-spec append_to_global_index([{event(), es_contract_event_store:position()}], file:filename()) ->
+    ok | {error, term()}.
+append_to_global_index(EventsWithPositions, EventFilePath) ->
+    IndexPath = global_index_path(),
+    IndexEntries = [
+        {Position, EventFilePath, es_contract_event:key(Event)}
+     || {Event, Position} <- EventsWithPositions
+    ],
+    IoData = [io_lib:format("~0p.~n", [Entry]) || Entry <- IndexEntries],
+    case file:write_file(IndexPath, IoData, [append]) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec fold_all(Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
+    Fun :: fun((Event :: event(), Position :: es_contract_event_store:position(), AccIn) -> AccOut),
+    Acc0 :: term(),
+    Range :: es_contract_range:range(),
+    Acc1 :: term(),
+    AccIn :: term(),
+    AccOut :: term(),
+    Reason :: term().
+fold_all(FoldFun, InitialAcc, Range) when is_function(FoldFun, 3) ->
+    From = es_contract_range:lower_bound(Range),
+    To = es_contract_range:upper_bound(Range),
+    IndexPath = global_index_path(),
+    case file:consult(IndexPath) of
+        {ok, IndexEntries} ->
+            %% Filter by position range
+            Filtered = [
+                {Position, FilePath, Key}
+             || {Position, FilePath, Key} <- IndexEntries,
+                within_range(Position, From, To)
+            ],
+            Sorted = lists:sort(fun({P1, _, _}, {P2, _, _}) -> P1 =< P2 end, Filtered),
+            fold_global_entries(Sorted, FoldFun, InitialAcc);
+        {error, enoent} ->
+            {ok, InitialAcc};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec fold_global_entries(
+    [{es_contract_event_store:position(), file:filename(), es_contract_event:key()}],
+    fun((event(), es_contract_event_store:position(), AccIn) -> AccOut),
+    AccIn
+) ->
+    {ok, AccOut} | {error, term()}
+when
+    AccIn :: term(),
+    AccOut :: term().
+fold_global_entries([], _FoldFun, Acc) ->
+    {ok, Acc};
+fold_global_entries([{Position, FilePath, Key} | Rest], FoldFun, Acc) ->
+    case load_event_by_key(FilePath, Key) of
+        {ok, Event} ->
+            fold_global_entries(Rest, FoldFun, FoldFun(Event, Position, Acc));
+        {error, Reason} ->
+            {error, {missing_global_index_event, Position, FilePath, Key, Reason}}
+    end.
+
+-spec load_event_by_key(file:filename(), es_contract_event:key()) ->
+    {ok, event()} | {error, not_found}.
+load_event_by_key(FilePath, Key) ->
+    case read_terms(FilePath) of
+        {ok, Events} ->
+            case lists:search(fun(E) -> es_contract_event:key(E) =:= Key end, Events) of
+                {value, Event} ->
+                    {ok, Event};
+                false ->
+                    {error, not_found}
+            end;
+        {error, _} ->
+            {error, not_found}
+    end.
+
+-spec position_counter_path() -> file:filename().
+position_counter_path() ->
+    filename:join(root_dir(), ?POSITION_COUNTER_FILE).
+
+-spec global_index_path() -> file:filename().
+global_index_path() ->
+    filename:join(root_dir(), ?GLOBAL_INDEX_FILE).

--- a/apps/es_store_mnesia/src/es_store_mnesia.erl
+++ b/apps/es_store_mnesia/src/es_store_mnesia.erl
@@ -96,15 +96,16 @@ start() ->
 stop() ->
     ok.
 
--spec append(StreamId, Events) -> ok when
+-spec append(StreamId, Events) -> ok | {error, Reason} when
     StreamId :: stream_id(),
-    Events :: [event()].
+    Events :: [event()],
+    Reason :: term().
 append(_, Events) ->
     case mnesia:transaction(fun() -> persist_events_in_tx(Events) end) of
         {atomic, _Result} ->
             ok;
         {aborted, Reason} ->
-            erlang:error(Reason)
+            {error, Reason}
     end.
 
 persist_events_in_tx([]) ->
@@ -125,16 +126,23 @@ persist_events_in_tx([#{stream_id := StreamId, sequence := Seq} = Event | Rest])
             persist_events_in_tx(Rest)
     end.
 
--spec fold(StreamId, Fun, Acc0, Range) -> Acc1 when
+-spec fold(StreamId, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
     StreamId :: stream_id(),
-    Fun :: fun((Event :: event(), AccIn) -> AccOut),
+    Fun :: fun(
+        (
+            Event :: event(),
+            Sequence :: sequence(),
+            AccIn
+        ) -> AccOut
+    ),
     Acc0 :: term(),
     Range :: es_contract_range:range(),
     Acc1 :: term(),
     AccIn :: term(),
-    AccOut :: term().
+    AccOut :: term(),
+    Reason :: term().
 fold(StreamId, FoldFun, InitialAcc, Range) when
-    is_function(FoldFun, 2)
+    is_function(FoldFun, 3)
 ->
     From = es_contract_range:lower_bound(Range),
     To = es_contract_range:upper_bound(Range),
@@ -143,7 +151,7 @@ fold(StreamId, FoldFun, InitialAcc, Range) when
             qlc:e(
                 qlc:q(
                     [
-                        E#event_record.event
+                        {E#event_record.sequence, E#event_record.event}
                      || E <- mnesia:table(event_table_name()),
                         E#event_record.stream_id =:= StreamId,
                         E#event_record.sequence >= From,
@@ -154,10 +162,15 @@ fold(StreamId, FoldFun, InitialAcc, Range) when
             )
         end,
     case mnesia:transaction(FunQuery) of
-        {atomic, Events} ->
-            lists:foldl(FoldFun, InitialAcc, Events);
+        {atomic, EventPairs} ->
+            Result = lists:foldl(
+                fun({Seq, Event}, Acc) -> FoldFun(Event, Seq, Acc) end,
+                InitialAcc,
+                EventPairs
+            ),
+            {ok, Result};
         {aborted, Reason} ->
-            erlang:error(Reason)
+            {error, Reason}
     end.
 
 -spec store(Snapshot) -> ok | {warning, Reason} when

--- a/apps/es_store_mnesia/src/es_store_mnesia.erl
+++ b/apps/es_store_mnesia/src/es_store_mnesia.erl
@@ -158,7 +158,9 @@ persist_events_in_tx(Events) when is_list(Events) ->
 
 persist_events_with_positions([], _Position) ->
     ok;
-persist_events_with_positions([#{stream_id := StreamId, sequence := Seq} = Event | Rest], Position) ->
+persist_events_with_positions(
+    [#{stream_id := StreamId, sequence := Seq} = Event | Rest], Position
+) ->
     Id = es_contract_event:key(Event),
     Record = #event_record{
         key = Id,

--- a/apps/es_store_mnesia/src/es_store_mnesia.erl
+++ b/apps/es_store_mnesia/src/es_store_mnesia.erl
@@ -12,6 +12,7 @@ The Mnesia-based implementation of the event store.
     start/0,
     stop/0,
     fold/4,
+    fold_all/3,
     append/2,
     store/1,
     load_latest/1
@@ -30,7 +31,11 @@ The Mnesia-based implementation of the event store.
 -type snapshot_data() :: es_contract_snapshot:state().
 
 -record(event_record, {
-    key :: event_id(), stream_id :: stream_id(), sequence :: sequence(), event :: event()
+    key :: event_id(),
+    stream_id :: stream_id(),
+    sequence :: sequence(),
+    position :: es_contract_event_store:position(),
+    event :: event()
 }).
 
 -record(snapshot_record, {
@@ -43,11 +48,13 @@ The Mnesia-based implementation of the event store.
 %% Default table names; overridable via application environment.
 -define(DEFAULT_EVENT_TABLE_NAME, events).
 -define(DEFAULT_SNAPSHOT_TABLE_NAME, snapshots).
+-define(DEFAULT_POSITION_COUNTER_TABLE_NAME, position_counter).
 
 -spec start() -> ok.
 start() ->
     EventTable = event_table_name(),
     SnapshotTable = snapshot_table_name(),
+    PositionCounterTable = position_counter_table_name(),
     try mnesia:table_info(EventTable, all) of
         _ ->
             ok
@@ -60,7 +67,7 @@ start() ->
                         {attributes, record_info(fields, event_record)},
                         {record_name, event_record},
                         {type, ordered_set},
-                        {index, [stream_id, sequence]}
+                        {index, [stream_id, sequence, position]}
                     ]
                 )
             of
@@ -90,6 +97,31 @@ start() ->
                 {aborted, SnapshotReason} ->
                     erlang:error(SnapshotReason)
             end
+    end,
+    %% Create position counter table if it doesn't exist
+    try mnesia:table_info(PositionCounterTable, all) of
+        _ ->
+            ok
+    catch
+        exit:{aborted, {no_exists, PositionCounterTable, all}} ->
+            case
+                mnesia:create_table(
+                    PositionCounterTable,
+                    [
+                        {attributes, [key, value]},
+                        {type, set}
+                    ]
+                )
+            of
+                {atomic, ok} ->
+                    %% Initialize global position counter to 0
+                    mnesia:dirty_write(
+                        PositionCounterTable, {PositionCounterTable, global_position, 0}
+                    ),
+                    ok;
+                {aborted, CounterReason} ->
+                    erlang:error(CounterReason)
+            end
     end.
 
 -spec stop() -> ok.
@@ -110,12 +142,29 @@ append(_, Events) ->
 
 persist_events_in_tx([]) ->
     ok;
-persist_events_in_tx([#{stream_id := StreamId, sequence := Seq} = Event | Rest]) ->
+persist_events_in_tx(Events) when is_list(Events) ->
+    %% Allocate positions for all events
+    PositionCounterTable = position_counter_table_name(),
+    NumEvents = length(Events),
+    [{_, global_position, CurrentPosition}] = mnesia:read(
+        PositionCounterTable, global_position, write
+    ),
+    NewPosition = CurrentPosition + NumEvents,
+    ok = mnesia:write(
+        PositionCounterTable, {PositionCounterTable, global_position, NewPosition}, write
+    ),
+    %% Persist events with assigned positions
+    persist_events_with_positions(Events, CurrentPosition).
+
+persist_events_with_positions([], _Position) ->
+    ok;
+persist_events_with_positions([#{stream_id := StreamId, sequence := Seq} = Event | Rest], Position) ->
     Id = es_contract_event:key(Event),
     Record = #event_record{
         key = Id,
         stream_id = StreamId,
         sequence = Seq,
+        position = Position,
         event = Event
     },
     case mnesia:read(event_table_name(), Id, read) of
@@ -123,7 +172,7 @@ persist_events_in_tx([#{stream_id := StreamId, sequence := Seq} = Event | Rest])
             mnesia:abort(duplicate_event);
         _ ->
             ok = mnesia:write(event_table_name(), Record, write),
-            persist_events_in_tx(Rest)
+            persist_events_with_positions(Rest, Position + 1)
     end.
 
 -spec fold(StreamId, Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
@@ -207,6 +256,46 @@ load_latest(StreamId) ->
             erlang:error(Reason)
     end.
 
+-spec fold_all(Fun, Acc0, Range) -> {ok, Acc1} | {error, Reason} when
+    Fun :: fun((Event :: event(), Position :: es_contract_event_store:position(), AccIn) -> AccOut),
+    Acc0 :: term(),
+    Range :: es_contract_range:range(),
+    Acc1 :: term(),
+    AccIn :: term(),
+    AccOut :: term(),
+    Reason :: term().
+fold_all(FoldFun, InitialAcc, Range) when is_function(FoldFun, 3) ->
+    From = es_contract_range:lower_bound(Range),
+    To = es_contract_range:upper_bound(Range),
+    FunQuery =
+        fun() ->
+            qlc:e(
+                qlc:q(
+                    [
+                        {E#event_record.event, E#event_record.position}
+                     || E <- mnesia:table(event_table_name()),
+                        E#event_record.position >= From,
+                        E#event_record.position < To
+                    ]
+                )
+            )
+        end,
+    case mnesia:transaction(FunQuery) of
+        {atomic, Results} ->
+            %% Sort results by position since QLC doesn't guarantee order
+            Sorted = lists:sort(fun({_, P1}, {_, P2}) -> P1 =< P2 end, Results),
+            Result = lists:foldl(
+                fun({Event, Position}, Acc) ->
+                    FoldFun(Event, Position, Acc)
+                end,
+                InitialAcc,
+                Sorted
+            ),
+            {ok, Result};
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
+
 -spec event_table_name() -> atom().
 event_table_name() ->
     application:get_env(es_store_mnesia, event_table_name, ?DEFAULT_EVENT_TABLE_NAME).
@@ -214,3 +303,9 @@ event_table_name() ->
 -spec snapshot_table_name() -> atom().
 snapshot_table_name() ->
     application:get_env(es_store_mnesia, snapshot_table_name, ?DEFAULT_SNAPSHOT_TABLE_NAME).
+
+-spec position_counter_table_name() -> atom().
+position_counter_table_name() ->
+    application:get_env(
+        es_store_mnesia, position_counter_table_name, ?DEFAULT_POSITION_COUNTER_TABLE_NAME
+    ).


### PR DESCRIPTION
Introduces the missing global event log primitive needed for projections.

Event stores now expose `fold_all`, ordered by global position, so read-side consumers can replay the whole log and resume from a stable offset. Positions are storage metadata and are kept out of domain events.

This also includes a breaking change to the event store contract: `fold` operations now return `{ok, Acc}` or {`error, Reason}` instead of a raw accumulator.

To come: live subscriptions and checkpointed projection runners...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event Store now assigns and tracks global positions for event replay and projection operations
  * Added projection behavior supporting CQRS read models with optional event filtering

* **Bug Fixes**
  * Improved error handling across event store operations with explicit error returns instead of thrown exceptions
  * Duplicate event handling now returns structured error responses

* **Documentation**
  * Expanded Event Store contract documentation clarifying stream-local and global replay semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->