### PR TITLE
✨ Feat/projection management

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ io:format(" -> ~p~n", [Dispatch(withdraw, 10)]),
 io:format("[4] withdraw $1000 (should fail)~n", []),
 io:format(" -> ~p~n", [Dispatch(withdraw, 1000)]),
 
+timer:sleep(500),
+
 ok.
 ```
 <!-- DEMO-END -->
@@ -179,13 +181,20 @@ es_projection:run_once(StoreContext, ProjectionModule, Options).
 
 % Start a polling projection runner
 es_projection:start_link(StoreContext, ProjectionModule, Options).
+
+% Start a managed polling projection runner under es_projection_sup
+es_projection:start(StoreContext, ProjectionModule, Options).
+
+% Locate or stop a managed projection by ProjectionModule:name/0
+es_projection:lookup(ProjectionName).
+es_projection:stop(ProjectionName).
 ```
 
 The runner owns checkpointing. It loads the last processed global position for `ProjectionModule:name/0`, consumes events with `es_kernel_store:fold_all/4`, applies `event_filter/1` when present, calls `handle_event/2`, and stores the checkpoint after each processed position. Filtered events are checkpointed too, so a projection can keep moving through the global log.
 
 By default, checkpoints are stored in ETS through `es_projection_checkpoint_ets`. Callers can provide another checkpoint backend with the `checkpoint_store` option. `start_position` defaults to `0`, and `poll_interval` defaults to `200` milliseconds.
 
-The polling runner is fail-fast: any store, checkpoint, or projection handling error stops the process. If automatic recovery is needed, start projection runners under a supervisor with the desired restart strategy. Projection runners are started explicitly by callers; they are not currently part of the `es_kernel_sup` supervision tree.
+The polling runner is fail-fast: any store, checkpoint, or projection handling error stops the process. `es_projection:start/3` starts runners under the projection dynamic supervisor and tracks them by projection name through the manager. `start_link/3` remains available for callers that want to own the runner process directly.
 
 #### Snapshot Store
 
@@ -228,7 +237,6 @@ Setting `snapshot_interval => 0` (default) disables automatic snapshotting.
 #### Additional future features
 
 - Add durable projection checkpoint backends for file or Mnesia stores if needed.
-- Add projection supervision/management helpers for named runners.
 - Support optional event subscriptions for real-time read-side updates.
 - Implement snapshot retention policies (e.g., keep only last N snapshots).
 

--- a/apps/es_projection/src/es_projection.app.src
+++ b/apps/es_projection/src/es_projection.app.src
@@ -1,12 +1,17 @@
 {application, es_projection, [
     {description, "Projection runtime for event sourcing implementation in Erlang"},
     {vsn, "0.1.0"},
-    {registered, []},
+    {registered, [es_projection_root_sup, es_projection_sup, es_projection_mgr]},
     {applications, [kernel, stdlib, es_kernel]},
+    {mod, {es_projection_app, []}},
     {modules, [
         es_contract_projection,
         es_contract_projection_checkpoint_store,
+        es_projection_app,
         es_projection_checkpoint_ets,
+        es_projection_mgr,
+        es_projection_root_sup,
+        es_projection_sup,
         es_projection
     ]},
     {licenses, ["BSD 3-Clause"]},

--- a/apps/es_projection/src/es_projection.erl
+++ b/apps/es_projection/src/es_projection.erl
@@ -15,7 +15,9 @@ strategy when automatic recovery is desired.
 
 -export([
     run_once/3,
+    start/3,
     start_link/3,
+    lookup/1,
     stop/1
 ]).
 
@@ -74,7 +76,25 @@ run_once(StoreContext, ProjectionModule, Options) ->
     end.
 
 -doc """
-Start a polling projection runner.
+Start a managed polling projection runner.
+""".
+-spec start(StoreContext, ProjectionModule, Options) -> {ok, pid()} | {error, Reason} when
+    StoreContext :: es_kernel_store:store_context(),
+    ProjectionModule :: module(),
+    Options :: options(),
+    Reason :: term().
+start(StoreContext, ProjectionModule, Options) ->
+    es_projection_mgr:start_projection(StoreContext, ProjectionModule, Options).
+
+-doc """
+Return the pid of a managed projection runner.
+""".
+-spec lookup(atom()) -> {ok, pid()} | {error, not_found}.
+lookup(ProjectionName) ->
+    es_projection_mgr:lookup(ProjectionName).
+
+-doc """
+Start a polling projection runner linked to the caller.
 """.
 -spec start_link(StoreContext, ProjectionModule, Options) -> gen_server:start_ret() when
     StoreContext :: es_kernel_store:store_context(),
@@ -91,8 +111,24 @@ start_link(StoreContext, ProjectionModule, Options) ->
 
 -doc """
 Stop a polling projection runner.
+
+When passed an atom, the managed projection with that name is stopped. Other
+server references are stopped directly. If no projection manager is running,
+an atom is treated as a locally registered runner name.
 """.
--spec stop(gen_server:server_ref()) -> ok.
+-spec stop(gen_server:server_ref()) -> ok | {error, not_found}.
+stop(ProjectionName) when is_atom(ProjectionName) ->
+    case erlang:whereis(es_projection_mgr) of
+        undefined ->
+            stop_local_or_not_found(ProjectionName);
+        _Pid ->
+            case es_projection_mgr:stop_projection(ProjectionName) of
+                ok ->
+                    ok;
+                {error, not_found} ->
+                    stop_local_or_not_found(ProjectionName)
+            end
+    end;
 stop(ServerRef) ->
     gen_server:stop(ServerRef).
 
@@ -172,6 +208,15 @@ init_runtime(StoreContext, ProjectionModule, Options) ->
             end;
         {error, Reason} ->
             {error, Reason}
+    end.
+
+-spec stop_local_or_not_found(atom()) -> ok | {error, not_found}.
+stop_local_or_not_found(Name) ->
+    case erlang:whereis(Name) of
+        undefined ->
+            {error, not_found};
+        _Pid ->
+            gen_server:stop(Name)
     end.
 
 -spec ensure_checkpoint_store_started(module()) -> ok | {error, term()}.

--- a/apps/es_projection/src/es_projection_app.erl
+++ b/apps/es_projection/src/es_projection_app.erl
@@ -1,0 +1,19 @@
+-module(es_projection_app).
+
+-moduledoc """
+OTP application callback for the projection runtime.
+""".
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+-spec start(application:start_type(), term()) -> {ok, pid()}.
+start(_StartType, _StartArgs) ->
+    es_projection_checkpoint_ets:start(),
+    es_projection_root_sup:start_link().
+
+-spec stop(term()) -> ok.
+stop(_State) ->
+    ok = es_projection_checkpoint_ets:stop(),
+    ok.

--- a/apps/es_projection/src/es_projection_mgr.erl
+++ b/apps/es_projection/src/es_projection_mgr.erl
@@ -1,0 +1,139 @@
+-module(es_projection_mgr).
+
+-moduledoc """
+Singleton manager for projection runner processes.
+""".
+
+-behaviour(gen_server).
+
+-export([
+    start_link/0,
+    stop/0,
+    start_projection/3,
+    stop_projection/1,
+    lookup/1
+]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-record(state, {
+    pids = #{} :: #{atom() => pid()},
+    monitors = #{} :: #{reference() => atom()}
+}).
+
+-opaque state() :: #state{}.
+-export_type([state/0]).
+
+-spec start_link() -> gen_server:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec stop() -> ok.
+stop() ->
+    gen_server:stop(?MODULE).
+
+-spec start_projection(StoreContext, ProjectionModule, Options) ->
+    {ok, pid()} | {error, Reason}
+when
+    StoreContext :: es_kernel_store:store_context(),
+    ProjectionModule :: module(),
+    Options :: es_projection:options(),
+    Reason :: term().
+start_projection(StoreContext, ProjectionModule, Options) ->
+    gen_server:call(?MODULE, {start_projection, StoreContext, ProjectionModule, Options}).
+
+-spec stop_projection(atom()) -> ok | {error, not_found}.
+stop_projection(ProjectionName) ->
+    gen_server:call(?MODULE, {stop_projection, ProjectionName}).
+
+-spec lookup(atom()) -> {ok, pid()} | {error, not_found}.
+lookup(ProjectionName) ->
+    gen_server:call(?MODULE, {lookup, ProjectionName}).
+
+-spec init([]) -> {ok, state()}.
+init([]) ->
+    {ok, #state{}}.
+
+-spec handle_call(term(), {pid(), term()}, state()) ->
+    {reply, term(), state()}.
+handle_call({start_projection, StoreContext, ProjectionModule, Options}, _From, State) ->
+    ProjectionName = ProjectionModule:name(),
+    case maps:find(ProjectionName, State#state.pids) of
+        {ok, Pid} ->
+            {reply, {ok, Pid}, State};
+        error ->
+            start_and_monitor(ProjectionName, StoreContext, ProjectionModule, Options, State)
+    end;
+handle_call({stop_projection, ProjectionName}, _From, State) ->
+    case maps:find(ProjectionName, State#state.pids) of
+        {ok, Pid} ->
+            ok = es_projection:stop(Pid),
+            {reply, ok, remove_projection(ProjectionName, State)};
+        error ->
+            {reply, {error, not_found}, State}
+    end;
+handle_call({lookup, ProjectionName}, _From, State) ->
+    case maps:find(ProjectionName, State#state.pids) of
+        {ok, Pid} ->
+            {reply, {ok, Pid}, State};
+        error ->
+            {reply, {error, not_found}, State}
+    end;
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info({'DOWN', MonitorRef, process, _Pid, _Reason}, State) ->
+    case maps:find(MonitorRef, State#state.monitors) of
+        {ok, ProjectionName} ->
+            {noreply, remove_projection(ProjectionName, State)};
+        error ->
+            {noreply, State}
+    end;
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+-spec code_change(term(), state(), term()) -> {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+-spec start_and_monitor(
+    atom(), es_kernel_store:store_context(), module(), es_projection:options(), state()
+) ->
+    {reply, {ok, pid()} | {error, term()}, state()}.
+start_and_monitor(ProjectionName, StoreContext, ProjectionModule, Options, State) ->
+    case es_projection_sup:start_projection(StoreContext, ProjectionModule, Options) of
+        {ok, Pid} ->
+            MonitorRef = erlang:monitor(process, Pid),
+            NewState = State#state{
+                pids = (State#state.pids)#{ProjectionName => Pid},
+                monitors = (State#state.monitors)#{MonitorRef => ProjectionName}
+            },
+            {reply, {ok, Pid}, NewState};
+        {error, Reason} ->
+            {reply, {error, Reason}, State}
+    end.
+
+-spec remove_projection(atom(), state()) -> state().
+remove_projection(ProjectionName, State) ->
+    Pids = maps:remove(ProjectionName, State#state.pids),
+    Monitors = maps:filter(
+        fun(_MonitorRef, Name) -> Name =/= ProjectionName end,
+        State#state.monitors
+    ),
+    State#state{pids = Pids, monitors = Monitors}.

--- a/apps/es_projection/src/es_projection_root_sup.erl
+++ b/apps/es_projection/src/es_projection_root_sup.erl
@@ -1,0 +1,43 @@
+-module(es_projection_root_sup).
+
+-moduledoc """
+Top-level supervisor for the projection application.
+""".
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+-spec start_link() -> supervisor:startlink_ret().
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 5
+    },
+    ChildSpecs = [
+        #{
+            id => es_projection_sup,
+            start => {es_projection_sup, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => supervisor,
+            modules => [es_projection_sup]
+        },
+        #{
+            id => es_projection_mgr,
+            start => {es_projection_mgr, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [es_projection_mgr]
+        }
+    ],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/es_projection/src/es_projection_sup.erl
+++ b/apps/es_projection/src/es_projection_sup.erl
@@ -1,0 +1,43 @@
+-module(es_projection_sup).
+
+-moduledoc """
+Dynamic supervisor for projection runners.
+""".
+
+-behaviour(supervisor).
+
+-export([start_link/0, start_projection/3]).
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+-spec start_link() -> supervisor:startlink_ret().
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+-spec start_projection(StoreContext, ProjectionModule, Options) ->
+    supervisor:startchild_ret()
+when
+    StoreContext :: es_kernel_store:store_context(),
+    ProjectionModule :: module(),
+    Options :: es_projection:options().
+start_projection(StoreContext, ProjectionModule, Options) ->
+    ProjectionName = ProjectionModule:name(),
+    ChildSpec = #{
+        id => {es_projection, ProjectionName},
+        start => {es_projection, start_link, [StoreContext, ProjectionModule, Options]},
+        restart => temporary,
+        shutdown => 5000,
+        type => worker,
+        modules => [es_projection]
+    },
+    supervisor:start_child(?SERVER, ChildSpec).
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 5
+    },
+    {ok, {SupFlags, []}}.

--- a/apps/es_projection/test/es_projection_management_tests.erl
+++ b/apps/es_projection/test/es_projection_management_tests.erl
@@ -1,0 +1,64 @@
+-module(es_projection_management_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(STORE, {es_store_ets, es_store_ets}).
+-define(STREAM_A, {user, <<"account-A">>}).
+
+suite_test_() ->
+    Tests = [
+        {"managed_runner_can_be_started_and_stopped",
+            fun managed_runner_can_be_started_and_stopped/0},
+        {"managed_runner_start_is_idempotent", fun managed_runner_start_is_idempotent/0},
+        {"dead_runner_is_removed_from_registry", fun dead_runner_is_removed_from_registry/0}
+    ],
+    {foreach, fun setup/0, fun teardown/1, Tests}.
+
+setup() ->
+    es_store_ets:start(),
+    {ok, _Started} = application:ensure_all_started(es_projection),
+    ok.
+
+teardown(_) ->
+    _ = es_projection:stop(collect_projection),
+    _ = es_projection:stop(failing_projection),
+    application:stop(es_projection),
+    es_store_ets:stop(),
+    ok.
+
+managed_runner_can_be_started_and_stopped() ->
+    ?assertEqual({error, not_found}, es_projection:lookup(collect_projection)),
+
+    {ok, Pid} = es_projection:start(?STORE, es_projection_collect, #{poll_interval => 20}),
+    ?assertEqual({ok, Pid}, es_projection:lookup(collect_projection)),
+
+    ?assertEqual(ok, es_projection:stop(collect_projection)),
+    ?assertEqual({error, not_found}, es_projection:lookup(collect_projection)).
+
+managed_runner_start_is_idempotent() ->
+    {ok, Pid} = es_projection:start(?STORE, es_projection_collect, #{poll_interval => 20}),
+    ?assertEqual(
+        {ok, Pid},
+        es_projection:start(?STORE, es_projection_collect, #{poll_interval => 20})
+    ),
+    ?assertEqual(ok, es_projection:stop(collect_projection)).
+
+dead_runner_is_removed_from_registry() ->
+    Timestamp = erlang:system_time(),
+    Event = es_kernel_store:new_event(?STREAM_A, user, fail, 1, Timestamp, #{}),
+    ?assertEqual(ok, es_kernel_store:append(?STORE, ?STREAM_A, [Event])),
+
+    {ok, Pid} = es_projection:start(?STORE, es_projection_failing, #{poll_interval => 20}),
+    ?assertEqual({ok, Pid}, es_projection:lookup(failing_projection)),
+    wait_until_removed(failing_projection, 20).
+
+wait_until_removed(_ProjectionName, 0) ->
+    ?assert(false);
+wait_until_removed(ProjectionName, AttemptsLeft) ->
+    case es_projection:lookup(ProjectionName) of
+        {error, not_found} ->
+            ok;
+        {ok, _Pid} ->
+            timer:sleep(20),
+            wait_until_removed(ProjectionName, AttemptsLeft - 1)
+    end.

--- a/apps/es_projection/test/es_projection_tests.erl
+++ b/apps/es_projection/test/es_projection_tests.erl
@@ -13,7 +13,8 @@ suite_test_() ->
         {"run_once_respects_start_position", fun run_once_respects_start_position/0},
         {"filtered_events_are_checkpointed", fun filtered_events_are_checkpointed/0},
         {"failed_event_is_not_checkpointed", fun failed_event_is_not_checkpointed/0},
-        {"polling_processes_later_events", fun polling_processes_later_events/0}
+        {"polling_processes_later_events", fun polling_processes_later_events/0},
+        {"named_runner_can_be_stopped_by_name", fun named_runner_can_be_stopped_by_name/0}
     ],
     {foreach, fun setup/0, fun teardown/1, Tests}.
 
@@ -107,6 +108,24 @@ polling_processes_later_events() ->
         wait_for_checkpoint(collect_projection, 0, 20)
     after
         es_projection:stop(Pid)
+    end.
+
+named_runner_can_be_stopped_by_name() ->
+    RunnerName = named_projection_runner,
+    {ok, Pid} = es_projection:start_link(
+        ?STORE, es_projection_collect, #{name => RunnerName, poll_interval => 20}
+    ),
+    try
+        ?assertEqual(Pid, erlang:whereis(RunnerName)),
+        ?assertEqual(ok, es_projection:stop(RunnerName)),
+        ?assertEqual(undefined, erlang:whereis(RunnerName))
+    after
+        case erlang:whereis(RunnerName) of
+            undefined ->
+                ok;
+            _ ->
+                es_projection:stop(RunnerName)
+        end
     end.
 
 append_sample_events() ->

--- a/apps/es_xp/examples/demo_bank.script
+++ b/apps/es_xp/examples/demo_bank.script
@@ -41,4 +41,6 @@ io:format(" -> ~p~n", [Dispatch(withdraw, 10)]),
 io:format("[4] withdraw $1000 (should fail)~n", []),
 io:format(" -> ~p~n", [Dispatch(withdraw, 1000)]),
 
+timer:sleep(500),
+
 ok.

--- a/apps/es_xp/src/bank_account_balance_projection.erl
+++ b/apps/es_xp/src/bank_account_balance_projection.erl
@@ -1,0 +1,40 @@
+-module(bank_account_balance_projection).
+
+-behaviour(es_contract_projection).
+
+-export([init/0, name/0, event_filter/1, handle_event/2]).
+
+init() ->
+    #{}.
+
+name() ->
+    bank_account_balance_projection.
+
+event_filter(#{aggregate_type := bank_account}) ->
+    true;
+event_filter(_) ->
+    false.
+
+handle_event(
+    #{stream_id := {bank_account, AccountId}, type := deposited, payload := #{amount := Amount}},
+    State
+) ->
+    NewState = update_balance(AccountId, Amount, State),
+    log_state(AccountId, NewState),
+    {ok, NewState};
+handle_event(
+    #{stream_id := {bank_account, AccountId}, type := withdrawn, payload := #{amount := Amount}},
+    State
+) ->
+    NewState = update_balance(AccountId, -Amount, State),
+    log_state(AccountId, NewState),
+    {ok, NewState};
+handle_event(_, State) ->
+    {ok, State}.
+
+update_balance(AccountId, Delta, State) ->
+    Balance = maps:get(AccountId, State, 0),
+    State#{AccountId => Balance + Delta}.
+
+log_state(AccountId, State) ->
+    logger:info("Bank account projection updated: account=~p state=~p", [AccountId, State]).

--- a/apps/es_xp/src/es_xp.app.src
+++ b/apps/es_xp/src/es_xp.app.src
@@ -3,9 +3,9 @@
     {vsn, "0.1.0"},
     {registered, []},
     {mod, {es_xp_app, []}},
-    {applications, [kernel, stdlib, es_store_ets, es_kernel]},
+    {applications, [kernel, stdlib, es_store_ets, es_kernel, es_projection]},
     {env, []},
-    {modules, [bank_account_aggregate, es_xp_app, es_xp_sup]},
+    {modules, [bank_account_aggregate, bank_account_balance_projection, es_xp_app, es_xp_sup]},
     {licenses, ["BSD 3-Clause"]},
     {links, []}
 ]}.

--- a/apps/es_xp/src/es_xp_app.erl
+++ b/apps/es_xp/src/es_xp_app.erl
@@ -12,7 +12,15 @@
 start(_StartType, _StartArgs) ->
     ok = es_kernel_registry:register(bank_account, bank_account_aggregate),
 
-    es_xp_sup:start_link().
+    case es_xp_sup:start_link() of
+        {ok, Pid} ->
+            StoreContext = es_kernel_app:get_store_context(),
+            {ok, _ProjectionPid} =
+                es_projection:start(StoreContext, bank_account_balance_projection, #{}),
+            {ok, Pid};
+        Error ->
+            Error
+    end.
 
 stop(_State) ->
     ok.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "apps/es_xp/**"


### PR DESCRIPTION
Adds a (small) management layer around projection runners: explicit _start/stop_ by projection name, _lookup_, _supervision_, and _cleanup_ when runners die.

Also wires the demo app to run a simple in-memory balance projection.