### PR TITLE
Feat/projection checkpoint file

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ es_projection:stop(ProjectionName).
 
 The runner owns checkpointing. It loads the last processed global position for `ProjectionModule:name/0`, consumes events with `es_kernel_store:fold_all/4`, applies `event_filter/1` when present, calls `handle_event/2`, and stores the checkpoint after each processed position. Filtered events are checkpointed too, so a projection can keep moving through the global log.
 
-By default, checkpoints are stored in ETS through `es_projection_checkpoint_ets`. Callers can provide another checkpoint backend with the `checkpoint_store` option. `start_position` defaults to `0`, and `poll_interval` defaults to `200` milliseconds.
+By default, checkpoints are stored in ETS through `es_projection_checkpoint_ets`. For persistent file checkpoints, set `checkpoint_store => es_projection_checkpoint_file` and configure its root directory with `application:set_env(es_projection, checkpoint_file_dir, Path)`. Callers can provide another checkpoint backend with the `checkpoint_store` option. `start_position` defaults to `0`, and `poll_interval` defaults to `200` milliseconds.
 
 The polling runner is fail-fast: any store, checkpoint, or projection handling error stops the process. `es_projection:start/3` starts runners under the projection dynamic supervisor and tracks them by projection name through the manager. `start_link/3` remains available for callers that want to own the runner process directly.
 

--- a/apps/es_projection/src/es_projection.app.src
+++ b/apps/es_projection/src/es_projection.app.src
@@ -9,6 +9,7 @@
         es_contract_projection_checkpoint_store,
         es_projection_app,
         es_projection_checkpoint_ets,
+        es_projection_checkpoint_file,
         es_projection_mgr,
         es_projection_root_sup,
         es_projection_sup,

--- a/apps/es_projection/src/es_projection_checkpoint_ets.erl
+++ b/apps/es_projection/src/es_projection_checkpoint_ets.erl
@@ -55,7 +55,7 @@ store_checkpoint(ProjectionName, Position) ->
 
 -spec table_name() -> atom().
 table_name() ->
-    application:get_env(es_kernel, projection_checkpoint_table_name, ?DEFAULT_TABLE_NAME).
+    application:get_env(es_projection, projection_checkpoint_table_name, ?DEFAULT_TABLE_NAME).
 
 -spec create_table(atom()) -> ok.
 create_table(Table) ->

--- a/apps/es_projection/src/es_projection_checkpoint_file.erl
+++ b/apps/es_projection/src/es_projection_checkpoint_file.erl
@@ -1,0 +1,101 @@
+-module(es_projection_checkpoint_file).
+-moduledoc """
+File-backed projection checkpoint store.
+
+Each projection checkpoint is stored as an atomically replaced binary term under
+a configurable directory. It survives projection-process and VM restarts.
+""".
+
+-behaviour(es_contract_projection_checkpoint_store).
+
+-export([
+    start/0,
+    stop/0,
+    load_checkpoint/1,
+    store_checkpoint/2
+]).
+
+-define(DEFAULT_ROOT_DIR, "./data/projection-checkpoints").
+-define(CHECKPOINT_EXT, ".checkpoint").
+
+-spec start() -> ok | {error, atom()}.
+start() ->
+    ensure_dir(root_dir()).
+
+-spec stop() -> ok.
+stop() ->
+    ok.
+
+-spec load_checkpoint(atom()) ->
+    {ok, es_contract_event_store:position()} | {error, not_found | term()}.
+load_checkpoint(ProjectionName) ->
+    Path = checkpoint_path(ProjectionName),
+    case file:read_file(Path) of
+        {ok, Binary} ->
+            decode_checkpoint(Binary);
+        {error, enoent} ->
+            {error, not_found};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec store_checkpoint(atom(), es_contract_event_store:position()) -> ok | {error, term()}.
+store_checkpoint(ProjectionName, Position) when is_integer(Position), Position >= 0 ->
+    case ensure_dir(root_dir()) of
+        ok ->
+            write_checkpoint(checkpoint_path(ProjectionName), Position);
+        {error, Reason} ->
+            {error, Reason}
+    end;
+store_checkpoint(_ProjectionName, _Position) ->
+    {error, invalid_position}.
+
+-spec write_checkpoint(file:filename(), es_contract_event_store:position()) ->
+    ok | {error, atom()}.
+write_checkpoint(Path, Position) ->
+    TemporaryPath = Path ++ ".tmp",
+    case file:write_file(TemporaryPath, term_to_binary(Position), [sync]) of
+        ok ->
+            case file:rename(TemporaryPath, Path) of
+                ok ->
+                    ok;
+                {error, Reason} ->
+                    _ = file:delete(TemporaryPath),
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec decode_checkpoint(binary()) -> {ok, es_contract_event_store:position()} | {error, term()}.
+decode_checkpoint(Binary) ->
+    try binary_to_term(Binary, [safe]) of
+        Position when is_integer(Position), Position >= 0 ->
+            {ok, Position};
+        _ ->
+            {error, invalid_checkpoint}
+    catch
+        error:badarg ->
+            {error, invalid_checkpoint}
+    end.
+
+-spec checkpoint_path(atom()) -> file:filename().
+checkpoint_path(ProjectionName) ->
+    Filename = binary_to_list(binary:encode_hex(atom_to_binary(ProjectionName, utf8))),
+    filename:join(root_dir(), Filename ++ ?CHECKPOINT_EXT).
+
+-spec root_dir() -> file:filename().
+root_dir() ->
+    to_string(application:get_env(es_projection, checkpoint_file_dir, ?DEFAULT_ROOT_DIR)).
+
+-spec ensure_dir(file:filename()) -> ok | {error, atom()}.
+ensure_dir(Dir) ->
+    filelib:ensure_dir(filename:join(Dir, ".keep")).
+
+-spec to_string(list() | binary() | atom()) -> string().
+to_string(Value) when is_list(Value) ->
+    Value;
+to_string(Value) when is_binary(Value) ->
+    binary_to_list(Value);
+to_string(Value) when is_atom(Value) ->
+    atom_to_list(Value).

--- a/apps/es_projection/test/es_projection_checkpoint_file_tests.erl
+++ b/apps/es_projection/test/es_projection_checkpoint_file_tests.erl
@@ -1,0 +1,129 @@
+-module(es_projection_checkpoint_file_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(STORE, {es_store_ets, es_store_ets}).
+-define(STREAM, {user, <<"file-checkpoint-account">>}).
+
+suite_test_() ->
+    Tests = [
+        {"stores_latest_checkpoint_across_restart", fun stores_latest_checkpoint_across_restart/0},
+        {"projection_runner_uses_file_checkpoint_store",
+            fun projection_runner_uses_file_checkpoint_store/0},
+        {"returns_file_errors", fun returns_file_errors/0},
+        {"rejects_invalid_positions", fun rejects_invalid_positions/0},
+        {"returns_write_errors", fun returns_write_errors/0},
+        {"cleans_up_after_rename_errors", fun cleans_up_after_rename_errors/0},
+        {"rejects_malformed_checkpoints", fun rejects_malformed_checkpoints/0},
+        {"accepts_binary_and_atom_checkpoint_directories",
+            fun accepts_binary_and_atom_checkpoint_directories/0}
+    ],
+    {foreach, fun setup/0, fun teardown/1, Tests}.
+
+setup() ->
+    RootDir = filename:join([
+        "_build",
+        "test",
+        "es_projection_checkpoint_file",
+        integer_to_list(erlang:unique_integer([positive]))
+    ]),
+    ok = application:set_env(es_projection, checkpoint_file_dir, RootDir),
+    ok = es_store_ets:start(),
+    ok = es_projection_checkpoint_file:start(),
+    RootDir.
+
+teardown(RootDir) ->
+    ok = es_projection_checkpoint_file:stop(),
+    ok = es_store_ets:stop(),
+    ok = application:unset_env(es_projection, checkpoint_file_dir),
+    _ = file:del_dir_r(RootDir),
+    ok.
+
+stores_latest_checkpoint_across_restart() ->
+    ?assertEqual(
+        {error, not_found}, es_projection_checkpoint_file:load_checkpoint(file_projection)
+    ),
+    ?assertEqual(ok, es_projection_checkpoint_file:store_checkpoint(file_projection, 3)),
+    ?assertEqual(ok, es_projection_checkpoint_file:store_checkpoint(file_projection, 8)),
+    ?assertEqual(ok, es_projection_checkpoint_file:stop()),
+    ?assertEqual(ok, es_projection_checkpoint_file:start()),
+    ?assertEqual({ok, 8}, es_projection_checkpoint_file:load_checkpoint(file_projection)).
+
+projection_runner_uses_file_checkpoint_store() ->
+    Event = es_kernel_store:new_event(?STREAM, user, created, 1, erlang:system_time(), #{}),
+    ?assertEqual(ok, es_kernel_store:append(?STORE, ?STREAM, [Event])),
+    ?assertMatch(
+        {ok, [created], 0},
+        es_projection:run_once(
+            ?STORE,
+            es_projection_collect,
+            #{checkpoint_store => es_projection_checkpoint_file}
+        )
+    ),
+    ?assertEqual({ok, 0}, es_projection_checkpoint_file:load_checkpoint(collect_projection)).
+
+returns_file_errors() ->
+    RootDir = checkpoint_root_dir(),
+    FileRoot = filename:join(RootDir, "not_a_directory"),
+    ok = file:write_file(FileRoot, <<>>),
+    ok = application:set_env(es_projection, checkpoint_file_dir, FileRoot),
+    ?assertMatch({error, _}, es_projection_checkpoint_file:start()),
+    ?assertMatch({error, _}, es_projection_checkpoint_file:load_checkpoint(file_error_projection)),
+    ?assertMatch(
+        {error, _}, es_projection_checkpoint_file:store_checkpoint(file_error_projection, 0)
+    ),
+    ok = application:set_env(es_projection, checkpoint_file_dir, RootDir).
+
+rejects_invalid_positions() ->
+    ?assertEqual(
+        {error, invalid_position},
+        es_projection_checkpoint_file:store_checkpoint(invalid_position_projection, -1)
+    ).
+
+returns_write_errors() ->
+    Path = checkpoint_path(write_error_projection),
+    ok = file:make_dir(Path ++ ".tmp"),
+    ?assertMatch(
+        {error, _}, es_projection_checkpoint_file:store_checkpoint(write_error_projection, 0)
+    ),
+    ok = file:del_dir(Path ++ ".tmp").
+
+cleans_up_after_rename_errors() ->
+    Path = checkpoint_path(rename_error_projection),
+    ok = file:make_dir(Path),
+    ?assertMatch(
+        {error, _}, es_projection_checkpoint_file:store_checkpoint(rename_error_projection, 0)
+    ),
+    ?assertNot(filelib:is_file(Path ++ ".tmp")),
+    ok = file:del_dir(Path).
+
+rejects_malformed_checkpoints() ->
+    Path = checkpoint_path(malformed_checkpoint_projection),
+    ok = file:write_file(Path, term_to_binary(-1)),
+    ?assertEqual(
+        {error, invalid_checkpoint},
+        es_projection_checkpoint_file:load_checkpoint(malformed_checkpoint_projection)
+    ),
+    ok = file:write_file(Path, <<"not an external term">>),
+    ?assertEqual(
+        {error, invalid_checkpoint},
+        es_projection_checkpoint_file:load_checkpoint(malformed_checkpoint_projection)
+    ).
+
+accepts_binary_and_atom_checkpoint_directories() ->
+    RootDir = checkpoint_root_dir(),
+    ok = application:set_env(es_projection, checkpoint_file_dir, list_to_binary(RootDir)),
+    ?assertEqual(ok, es_projection_checkpoint_file:start()),
+    AtomRootDir = projection_checkpoint_file_atom_root,
+    ok = application:set_env(es_projection, checkpoint_file_dir, AtomRootDir),
+    ?assertEqual(ok, es_projection_checkpoint_file:start()),
+    ok = application:set_env(es_projection, checkpoint_file_dir, RootDir),
+    _ = file:del_dir_r(atom_to_list(AtomRootDir)).
+
+checkpoint_root_dir() ->
+    {ok, RootDir} = application:get_env(es_projection, checkpoint_file_dir),
+    RootDir.
+
+checkpoint_path(ProjectionName) ->
+    Filename = binary_to_list(binary:encode_hex(atom_to_binary(ProjectionName, utf8))),
+    filename:join(checkpoint_root_dir(), Filename ++ ".checkpoint").

--- a/apps/es_projection/test/es_projection_tests.erl
+++ b/apps/es_projection/test/es_projection_tests.erl
@@ -14,6 +14,8 @@ suite_test_() ->
         {"filtered_events_are_checkpointed", fun filtered_events_are_checkpointed/0},
         {"failed_event_is_not_checkpointed", fun failed_event_is_not_checkpointed/0},
         {"polling_processes_later_events", fun polling_processes_later_events/0},
+        {"checkpoint_table_uses_projection_application_env",
+            fun checkpoint_table_uses_projection_application_env/0},
         {"named_runner_can_be_stopped_by_name", fun named_runner_can_be_stopped_by_name/0}
     ],
     {foreach, fun setup/0, fun teardown/1, Tests}.
@@ -127,6 +129,15 @@ named_runner_can_be_stopped_by_name() ->
                 es_projection:stop(RunnerName)
         end
     end.
+
+checkpoint_table_uses_projection_application_env() ->
+    CustomTable = projection_checkpoints_test,
+    ok = application:set_env(es_projection, projection_checkpoint_table_name, CustomTable),
+    ok = es_projection_checkpoint_ets:start(),
+    ?assertNotEqual(undefined, ets:info(CustomTable)),
+    ok = es_projection_checkpoint_ets:stop(),
+    ok = application:unset_env(es_projection, projection_checkpoint_table_name),
+    ok = es_projection_checkpoint_ets:start().
 
 append_sample_events() ->
     Timestamp = erlang:system_time(),


### PR DESCRIPTION
Add `es_projection_checkpoint_file`, a persistent file-backed checkpoint provider for projections.
Projections can now resume from their last processed event after a restart, without replaying events already handled.